### PR TITLE
fix: Pinning Pydantic<2.0 as Traefik-k8s ingress lib dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema
 jinja2
 ops
-pydantic
+pydantic<2.0
 pytest-interface-tester


### PR DESCRIPTION
# Description

Pinning Pydantic<2.0 as Traefik-k8s ingress lib dependency to fix the integration tests

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library