### PR TITLE
fix: Pinning Juju version to latest working (3.3.0.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 jsonschema
 jinja2
+juju==3.3.0.0
 ops
 pydantic<2.0
 pytest-interface-tester


### PR DESCRIPTION
# Description

Pinning `juju` version to 3.3.0.0, which is last working. With 3.3.1.0 tests started failing because of 
```shell
 File "/home/ubuntu/github-runner/_work/sdcore-tests/sdcore-tests/.tox/integration/lib/python3.10/site-packages/juju/version.py", line 19, in <module>
    CLIENT_VERSION = re.search(r'\d+\.\d+\.\d+', open(VERSION_FILE_PATH).read().strip()).group()
FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/github-runner/_work/sdcore-tests/sdcore-tests/.tox/integration/lib/python3.10/site-packages/VERSION'
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library