### PR TITLE
chore: bump pydantic to v2.5.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,5 +2,5 @@ jsonschema
 jinja2
 juju==3.3.1.1
 ops
-pydantic<2.0
+pydantic==2.5.3
 pytest-interface-tester

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+annotated-types==0.6.0
+    # via pydantic
 attrs==23.2.0
     # via
     #   jsonschema
@@ -79,10 +81,12 @@ pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
-pydantic==1.10.14
+pydantic==2.5.3
     # via
     #   -r requirements.in
     #   pytest-interface-tester
+pydantic-core==2.14.6
+    # via pydantic
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -139,6 +143,7 @@ typer==0.7.0
 typing-extensions==4.10.0
     # via
     #   pydantic
+    #   pydantic-core
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju


### PR DESCRIPTION
# Description

Bump pydantic to v2.5.3.

## Note

Unfortunately we can't go higher at the moment because the `rustc` package from the apt repo for Ubuntu 22.04 used in the Charm isn't compatible. You can read more about this here: https://github.com/pydantic/pydantic-core/issues/1176

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library