### PR TITLE
chore: Centralize status management

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -17,10 +17,10 @@ from charms.sdcore_webui_k8s.v0.sdcore_management import (  # type: ignore[impor
     SdcoreManagementRequires,
 )
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer  # type: ignore[import]
+from ops import ActiveStatus, BlockedStatus, CollectStatusEvent, WaitingStatus
 from ops.charm import CharmBase
 from ops.framework import EventBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer
 
 logger = logging.getLogger(__name__)
@@ -53,6 +53,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
             strip_prefix=True,
         )
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         self.framework.observe(self.on.nms_pebble_ready, self._configure_sdcore_nms)
         self.framework.observe(self.on.update_status, self._configure_sdcore_nms)
         self.framework.observe(self.fiveg_n4.on.fiveg_n4_available, self._configure_sdcore_nms)
@@ -72,20 +73,14 @@ class SDCoreNMSOperatorCharm(CharmBase):
             event (EventBase): Juju event.
         """
         if not self._container.can_connect():
-            self.unit.status = WaitingStatus("Waiting for container to be ready")
             return
         if not self.model.relations.get(SDCORE_MANAGEMENT_RELATION_NAME):
-            self.unit.status = BlockedStatus(
-                f"Waiting for `{SDCORE_MANAGEMENT_RELATION_NAME}` relation to be created"
-            )
             return
         if not self._sdcore_management.management_url:
-            self.unit.status = WaitingStatus("Waiting for webui management url to be available")
             return
         self._configure_upf_information()
         self._configure_gnb_information()
         self._configure_pebble()
-        self.unit.status = ActiveStatus()
 
     def _configure_pebble(self) -> None:
         """Configure the Pebble layer."""
@@ -94,6 +89,30 @@ class SDCoreNMSOperatorCharm(CharmBase):
         if plan.services != layer.services:
             self._container.add_layer(self._container_name, layer, combine=True)
             self._container.restart(self._service_name)
+
+    def _on_collect_unit_status(self, event: CollectStatusEvent):
+        """Check the unit status and set to Unit when CollectStatusEvent is fired.
+
+        Args:
+            event: CollectStatusEvent
+        """
+        if not self._container.can_connect():
+            event.add_status(WaitingStatus("Waiting for container to be ready"))
+            logger.info("Waiting for container to be ready")
+            return
+        if not self.model.relations.get(SDCORE_MANAGEMENT_RELATION_NAME):
+            event.add_status(
+                BlockedStatus(
+                    f"Waiting for `{SDCORE_MANAGEMENT_RELATION_NAME}` relation to be created"
+                )
+            )
+            logger.info(f"Waiting for `{SDCORE_MANAGEMENT_RELATION_NAME}` relation to be created")
+            return
+        if not self._sdcore_management.management_url:
+            event.add_status(WaitingStatus("Waiting for webui management url to be available"))
+            logger.info("Waiting for webui management url to be available")
+            return
+        event.add_status(ActiveStatus())
 
     def _configure_upf_information(self) -> None:
         """Creates the UPF config file.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -79,7 +79,7 @@ class TestCharm(unittest.TestCase):
         self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
-            WaitingStatus("Waiting for webui management url to be available"),
+            WaitingStatus("Waiting for webui management URL to be available"),
         )
 
     def test_given_management_url_available_when_pebble_ready_then_status_is_active(self):
@@ -659,4 +659,100 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             json.loads((root / "nms/config/gnb_config.json").read_text()), expected_gnb_config
+        )
+
+    def test_given_storage_not_available_when_pebble_ready_then_status_is_waiting(self):
+        gnb_identity_relation_id = self.harness.add_relation(
+            relation_name=GNB_IDENTITY_RELATION_NAME,
+            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=gnb_identity_relation_id,
+            app_or_unit=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+            key_values={"gnb_name": "some.gnb", "tac": "1234"},
+        )
+        sdcore_management_relation_id = self.harness.add_relation(
+            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
+            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=sdcore_management_relation_id,
+            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+            key_values={"management_url": "http://10.0.0.1:5000"},
+        )
+
+        self.harness.container_pebble_ready("nms")
+        self.harness.evaluate_status()
+
+        self.assertEqual(
+            self.harness.model.unit.status, WaitingStatus("Waiting for storage to be attached")
+        )
+
+    def test_given_upf_config_file_not_available_when_evaluate_status_then_status_is_waiting(self):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        (root / "nms/config/gnb_config.json").write_text("[]")
+
+        sdcore_management_relation_id = self.harness.add_relation(
+            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
+            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=sdcore_management_relation_id,
+            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+            key_values={"management_url": "http://10.0.0.1:5000"},
+        )
+
+        self.harness.set_can_connect(container="nms", val=True)
+        self.harness.evaluate_status()
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            WaitingStatus("Waiting for UPF config file to be stored"),
+        )
+
+    def test_given_gnb_config_file_not_available_when_evaluate_status_then_status_is_waiting(self):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        (root / "nms/config/upf_config.json").write_text("[]")
+
+        sdcore_management_relation_id = self.harness.add_relation(
+            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
+            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=sdcore_management_relation_id,
+            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+            key_values={"management_url": "http://10.0.0.1:5000"},
+        )
+
+        self.harness.set_can_connect(container="nms", val=True)
+        self.harness.evaluate_status()
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            WaitingStatus("Waiting for GNB config file to be stored"),
+        )
+
+    def test_given_service_is_not_running_when_evaluate_status_then_status_is_waiting(self):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        (root / "nms/config/upf_config.json").write_text("[]")
+        (root / "nms/config/gnb_config.json").write_text("[]")
+
+        sdcore_management_relation_id = self.harness.add_relation(
+            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
+            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=sdcore_management_relation_id,
+            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+            key_values={"management_url": "http://10.0.0.1:5000"},
+        )
+
+        self.harness.set_can_connect(container="nms", val=True)
+        self.harness.evaluate_status()
+
+        self.assertEqual(
+            self.harness.model.unit.status, WaitingStatus("Waiting for NMS service to start")
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,6 +44,7 @@ class TestCharm(unittest.TestCase):
         self,
     ):
         self.harness.charm._configure_sdcore_nms(event=Mock())
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for container to be ready")
         )
@@ -60,6 +61,7 @@ class TestCharm(unittest.TestCase):
             remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
         )
         self.harness.container_pebble_ready("nms")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus(
@@ -74,6 +76,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for webui management url to be available"),
@@ -92,6 +95,7 @@ class TestCharm(unittest.TestCase):
             key_values={"management_url": "http://10.0.0.1:5000"},
         )
         self.harness.container_pebble_ready("nms")
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     def test_given_n4_information_not_available_when_pebble_ready_then_status_is_active(
@@ -115,6 +119,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     def test_given_gnb_identity_information_not_available_when_pebble_ready_then_status_is_active(
@@ -138,6 +143,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     def test_given_gnb_identity_gnb_name_not_available_when_pebble_ready_then_status_is_active(
@@ -166,6 +172,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     def test_given_gnb_identity_tac_not_available_when_pebble_ready_then_status_is_active(
@@ -194,6 +201,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     def test_given_gnb_identity_information_not_available_in_one_relation_when_pebble_ready_then_status_is_active(  # noqa: E501
@@ -228,6 +236,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     def test_given_all_relations_created_when_pebble_ready_then_pebble_plan_is_applied(
@@ -358,6 +367,7 @@ class TestCharm(unittest.TestCase):
             app_or_unit=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
             key_values={"gnb_name": "some.gnb", "tac": "1234"},
         )
+        self.harness.evaluate_status()
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 


### PR DESCRIPTION
# Description

This PR uses new ops feature CollectStatus Event to manage status Charm. Event named collect_unit_status sets the status of charm automatically at the end of every hook.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library