### PR TITLE
chore: Move to codespell and ruff 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,27 +9,29 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "lib/charms/data_platform_libs", "lib/charms/observability_libs", "lib/charms/prometheus_k8s", "lib/charms/sdcore_nrf"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
 
 [[tool.mypy.overrides]]
 module = ["ops.*", "kubernetes.*", "flatten_json.*", "git.*"]
@@ -38,3 +40,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["charms.*"]
 follow_imports = "silent"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,7 +143,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
         return True
 
     def _configure_upf_information(self) -> None:
-        """Creates the UPF config file.
+        """Create the UPF config file.
 
         The config file is generated based on the various `fiveg_n4` relations and their content.
         """
@@ -158,7 +158,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
             self._push_upf_config_file_to_workload(upf_config_content)
 
     def _configure_gnb_information(self) -> None:
-        """Creates the GNB config file.
+        """Create the GNB config file.
 
         The config file is generated based on the various `fiveg_gnb_identity` relations
         and their content.
@@ -174,7 +174,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
             self._push_gnb_config_file_to_workload(gnb_config_content)
 
     def _get_existing_config_file(self, path: str) -> str:
-        """Gets the existing config file from the workload.
+        """Get the existing config file from the workload.
 
         Args:
             path (str): Path to the config file.
@@ -188,7 +188,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
         return ""
 
     def _get_upf_host_port_list(self) -> List[Tuple[str, int]]:
-        """Gets the list of UPF hosts and ports from the `fiveg_n4` relation data bag.
+        """Get the list of UPF hosts and ports from the `fiveg_n4` relation data bag.
 
         Returns:
             List[Tuple[str, int]]: List of UPF hostnames and ports.
@@ -208,7 +208,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
         return upf_host_port_list
 
     def _get_gnb_name_tac_list(self) -> List[Tuple[str, int]]:
-        """Gets a list gnb_name and TAC from the `fiveg_gnb_identity` relation data bag.
+        """Get a list gnb_name and TAC from the `fiveg_gnb_identity` relation data bag.
 
         Returns:
             List[Tuple[str, int]]: List of gnb_name and TAC.
@@ -228,7 +228,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
         return gnb_name_tac_list
 
     def _get_upf_config(self) -> str:
-        """Gets the UPF configuration for the NMS in a json.
+        """Get the UPF configuration for the NMS in a json.
 
         Returns:
             str: Json representation of list of dictionaries,
@@ -246,7 +246,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
         return json.dumps(upf_config, sort_keys=True)
 
     def _get_gnb_config(self) -> str:
-        """Gets the GNB configuration for the NMS in a json format.
+        """Get the GNB configuration for the NMS in a json format.
 
         Returns:
             str: Json representation of list of dictionaries,
@@ -295,7 +295,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
 
     @property
     def _environment_variables(self) -> dict:
-        """Returns environment variables for the nms service.
+        """Return environment variables for the nms service.
 
         Returns:
             dict: Environment variables.
@@ -308,7 +308,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
 
 
 def config_file_content_matches(existing_content: str, new_content: str) -> bool:
-    """Returns whether two config file contents match."""
+    """Return whether two config file contents match."""
     try:
         existing_content_list = json.loads(existing_content)
         new_content_list = json.loads(new_content)

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,15 +1,11 @@
-black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 juju
 mypy
-pep8-naming
-pyproject-flake8
 pytest
 pytest-operator
 requests
+ruff
 types-PyYAML
 types-setuptools
 types-toml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,6 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-black==24.3.0
-    # via -r test-requirements.in
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -18,32 +16,25 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via black
+codespell==2.2.6
+    # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==7.0.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.5.0
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -51,17 +42,19 @@ hvac==2.1.0
 idna==3.6
     # via requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.2
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
     # via
     #   -r test-requirements.in
@@ -71,16 +64,15 @@ kubernetes==29.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
 mypy==1.9.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
-    #   black
     #   mypy
     #   typing-inspect
 oauthlib==3.2.2
@@ -89,23 +81,19 @@ oauthlib==3.2.2
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   black
+    # -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
-pep8-naming==0.13.3
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.0
-    # via black
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.3
@@ -121,14 +109,10 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
-    # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.2.0
-    # via flake8
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -138,14 +122,13 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==7.0.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -159,6 +142,7 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
@@ -173,6 +157,8 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.5
+    # via -r test-requirements.in
 six==1.16.0
     # via
     #   asttokens
@@ -180,8 +166,6 @@ six==1.16.0
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -209,6 +193,8 @@ urllib3==2.2.1
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -93,7 +93,7 @@ async def deploy_grafana_agent(ops_test):
 
 
 async def get_sdcore_nms_endpoint(ops_test) -> str:
-    """Retrieves the SD-Core NMS endpoint by using Traefik's `show-proxied-endpoints` action."""
+    """Retrieve the SD-Core NMS endpoint by using Traefik's `show-proxied-endpoints` action."""
     traefik = ops_test.model.applications[TRAEFIK_APP_NAME]
     traefik_unit = traefik.units[0]
     t0 = time.time()
@@ -117,18 +117,18 @@ async def get_sdcore_nms_endpoint(ops_test) -> str:
 
 
 async def get_traefik_ip(ops_test) -> str:
-    """Retrieves the IP of the Traefik Application."""
+    """Retrieve the IP of the Traefik Application."""
     app_status = await ops_test.model.get_status(filters=[TRAEFIK_APP_NAME])
     return app_status.applications[TRAEFIK_APP_NAME].public_address
 
 
 def _get_host_from_url(url: str) -> str:
-    """Returns the host from a URL formatted as http://<host>:<port>/ or as http://<host>/."""
+    """Return the host from a URL formatted as http://<host>:<port>/ or as http://<host>/."""
     return url.split("//")[1].split(":")[0].split("/")[0]
 
 
 def ui_is_running(ip: str, host: str) -> bool:
-    """Returns whether the UI is running."""
+    """Return whether the UI is running."""
     url = f"http://{ip}/network-configuration"
     headers = {"Host": host}
     t0 = time.time()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,10 +5,9 @@ import json
 import unittest
 from unittest.mock import Mock
 
+from charm import SDCoreNMSOperatorCharm
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
-
-from charm import SDCoreNMSOperatorCharm
 
 FIVEG_N4_RELATION_NAME = "fiveg_n4"
 TEST_FIVEG_N4_PROVIDER_APP_NAME = "fiveg_n4_provider_app"
@@ -21,7 +20,7 @@ TEST_GNB_CONFIG_PATH = "/nms/config/gnb_config.json"
 
 
 def read_file(path: str) -> str:
-    """Reads a file and returns as a string.
+    """Read a file and returns as a string.
 
     Args:
         path (str): path to the file.

--- a/tox.ini
+++ b/tox.ini
@@ -28,15 +28,13 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks


### PR DESCRIPTION
# Description

Move to ruff and codespell for linting. `pyproject-flake8` is currently broken on Python 3.12, making development on Noble break.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library