### PR TITLE
chore: enable ruff line length check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ line-length = 99
 [tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]
 extend-ignore = [
+    "D107",
     "D203",
     "D204",
     "D213",
@@ -27,7 +28,6 @@ extend-ignore = [
     "D409",
     "D413",
 ]
-ignore = ["E501", "D107"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.lint.mccabe]


### PR DESCRIPTION
# Description

Enable line length check (E501) in ruff


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library