### PR TITLE
fix: NMS restart

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -88,10 +88,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
         """Configure the Pebble layer."""
         plan = self._container.get_plan()
         layer = self._pebble_layer
-        logger.info("Plan services %s", plan.services)
-        logger.info("layer services %s", layer.services)
         if plan.services != layer.services:
-            logger.info("RESTARTING")
             self._container.add_layer(self._container_name, layer, combine=True)
             self._container.restart(self._service_name)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -40,8 +40,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self._container_name = "nms"
-        self._service_name = "sdcore-nms"
+        self._container_name = self._service_name = "nms"
         self._container = self.unit.get_container(self._container_name)
         self.fiveg_n4 = N4Requires(charm=self, relation_name=FIVEG_N4_RELATION_NAME)
         self._gnb_identity = GnbIdentityRequires(self, GNB_IDENTITY_RELATION_NAME)
@@ -89,7 +88,10 @@ class SDCoreNMSOperatorCharm(CharmBase):
         """Configure the Pebble layer."""
         plan = self._container.get_plan()
         layer = self._pebble_layer
+        logger.info("Plan services %s", plan.services)
+        logger.info("layer services %s", layer.services)
         if plan.services != layer.services:
+            logger.info("RESTARTING")
             self._container.add_layer(self._container_name, layer, combine=True)
             self._container.restart(self._service_name)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -278,7 +278,7 @@ class TestCharm(unittest.TestCase):
 
         expected_plan = {
             "services": {
-                "sdcore-nms": {
+                "nms": {
                     "startup": "enabled",
                     "override": "replace",
                     "command": "/bin/bash -c 'cd /app && npm run start'",
@@ -314,7 +314,7 @@ class TestCharm(unittest.TestCase):
 
         expected_plan = {
             "services": {
-                "sdcore-nms": {
+                "nms": {
                     "startup": "enabled",
                     "override": "replace",
                     "command": "/bin/bash -c 'cd /app && npm run start'",


### PR DESCRIPTION
# Description

fix https://github.com/canonical/sdcore-nms-k8s-operator/issues/90
Issue: Every time the update status event is fired, the Pebble service is restarted.

The Service name specified in Rockcraft is `nms`.
The one defined in the pebble layer is `sdcore-nms`. 
In every update status event, the container plan and the pebble layer were different, which triggered a service restart.


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library