### PR TITLE
fix: config file update on relation broken

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -17,7 +17,14 @@ from charms.sdcore_webui_k8s.v0.sdcore_management import (  # type: ignore[impor
     SdcoreManagementRequires,
 )
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer  # type: ignore[import]
-from ops import ActiveStatus, BlockedStatus, CollectStatusEvent, ModelError, WaitingStatus
+from ops import (
+    ActiveStatus,
+    BlockedStatus,
+    CollectStatusEvent,
+    ModelError,
+    RelationBrokenEvent,
+    WaitingStatus,
+)
 from ops.charm import CharmBase
 from ops.framework import EventBase
 from ops.main import main
@@ -64,6 +71,14 @@ class SDCoreNMSOperatorCharm(CharmBase):
         self.framework.observe(
             self._gnb_identity.on.fiveg_gnb_identity_available,
             self._configure_sdcore_nms,
+        )
+        self.framework.observe(
+            self.on[GNB_IDENTITY_RELATION_NAME].relation_broken,
+            self._on_fiveg_gnb_identity_relation_broken,
+        )
+        self.framework.observe(
+            self.on[FIVEG_N4_RELATION_NAME].relation_broken,
+            self._on_fiveg_n4_relation_broken,
         )
 
     def _configure_sdcore_nms(self, event: EventBase) -> None:
@@ -140,6 +155,22 @@ class SDCoreNMSOperatorCharm(CharmBase):
         except ModelError:
             return False
         return True
+
+    def _on_fiveg_gnb_identity_relation_broken(self, event: RelationBrokenEvent):
+        """Update the GNB config file."""
+        if not self._container.can_connect():
+            return
+        if not self._container.exists(path=CONFIG_DIR_PATH):
+            return
+        self._configure_gnb_information()
+
+    def _on_fiveg_n4_relation_broken(self, event: RelationBrokenEvent):
+        """Update the UPF config file."""
+        if not self._container.can_connect():
+            return
+        if not self._container.exists(path=CONFIG_DIR_PATH):
+            return
+        self._configure_upf_information()
 
     def _configure_upf_information(self) -> None:
         """Create the UPF config file.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -370,6 +370,60 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
+    def test_given_no_sdcore_management_relation_when_pebble_ready_then_upf_config_generated_and_pushed(  # noqa: E501
+        self,
+    ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        expected_upf_config = [
+            {
+                "hostname": "some.host.name",
+                "port": "1234",
+            }
+        ]
+        fiveg_n4_relation_id = self.harness.add_relation(
+            relation_name=FIVEG_N4_RELATION_NAME,
+            remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=fiveg_n4_relation_id,
+            app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+            key_values={"upf_hostname": "some.host.name", "upf_port": "1234"},
+        )
+
+        self.harness.container_pebble_ready("nms")
+
+        self.assertEqual(
+            json.loads((root / "nms/config/upf_config.json").read_text()), expected_upf_config
+        )
+
+    def test_given_no_sdcore_management_relation_when_pebble_ready_then_gnb_config_generated_and_pushed(  # noqa: E501
+        self,
+    ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        expected_gnb_config = [
+            {
+                "name": "some.gnb",
+                "tac": "1234",
+            }
+        ]
+        gnb_identity_relation_id = self.harness.add_relation(
+            relation_name=GNB_IDENTITY_RELATION_NAME,
+            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=gnb_identity_relation_id,
+            app_or_unit=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+            key_values={"gnb_name": "some.gnb", "tac": "1234"},
+        )
+
+        self.harness.container_pebble_ready("nms")
+
+        self.assertEqual(
+            json.loads((root / "nms/config/gnb_config.json").read_text()), expected_gnb_config
+        )
+
     def test_given_n4_information_available_when_pebble_ready_then_upf_config_generated_and_pushed(  # noqa: E501
         self,
     ):
@@ -682,15 +736,6 @@ class TestCharm(unittest.TestCase):
             app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
             key_values={"upf_hostname": "some.other.host.name", "upf_port": "4567"},
         )
-        sdcore_management_relation_id = self.harness.add_relation(
-            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
-            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-        )
-        self.harness.update_relation_data(
-            relation_id=sdcore_management_relation_id,
-            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-            key_values={"management_url": "http://10.0.0.1:5000"},
-        )
         self.harness.container_pebble_ready("nms")
 
         self.harness.remove_relation(fiveg_n4_relation_1_id)
@@ -726,15 +771,6 @@ class TestCharm(unittest.TestCase):
             relation_id=gnb_identity_relation_2_id,
             app_or_unit=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
             key_values={"gnb_name": "some.other.gnb.name", "tac": "4567"},
-        )
-        sdcore_management_relation_id = self.harness.add_relation(
-            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
-            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-        )
-        self.harness.update_relation_data(
-            relation_id=sdcore_management_relation_id,
-            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-            key_values={"management_url": "http://10.0.0.1:5000"},
         )
         self.harness.container_pebble_ready("nms")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -813,7 +813,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.remove_relation(gnb_identity_relation_id)
 
-    def test_given_cannot_connet_to_container_when_n4_relation_broken_then_no_exception_is_raised(  # noqa: E501
+    def test_given_cannot_connect_to_container_when_n4_relation_broken_then_no_exception_is_raised(  # noqa: E501
         self
     ):
         fiveg_n4_relation_id = self.harness.add_relation(


### PR DESCRIPTION
# Description

fix https://github.com/canonical/sdcore-nms-k8s-operator/issues/27

Call the update gnb/upf config file methods on relation broken events.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library