### PR TITLE
chore: Adding v1.4 label to PRs from depenadabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore: "
+    labels:
+      - v1.4
 
   - package-ecosystem: "pip"
     target-branch: v1.4
@@ -36,6 +38,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore: "
+    labels:
+      - v1.4
 
   - package-ecosystem: "terraform"
     target-branch: v1.4
@@ -44,3 +48,5 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore: "
+    labels:
+      - v1.4

--- a/.github/workflows/dependabot_pr.yaml
+++ b/.github/workflows/dependabot_pr.yaml
@@ -2,6 +2,9 @@ name: "Dependabot Auto Approve and Merge"
 
 on:
   pull_request:
+    branches:
+      - main
+      - v1.4
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
# Description

Adds `v1.4` label to PRs from Depenadabot created for 1.4 branch

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library