### PR TITLE
chore: Small change to use latest OCI image with fixed documentation links

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ name: sdcore-nms-k8s
 
 display-name: SD-Core NMS K8s
 summary: A Charmed Operator for SD-Core's NMS.
-description: A Charmed Operator for SD-Core's Network Management System (NMS).
+description: A Charmed Operator for SD-Core's Network Management System (NMS) for K8s.
 website: https://charmhub.io/sdcore-nms-k8s
 source: https://github.com/canonical/sdcore-nms-k8s-operator
 issues: https://github.com/canonical/sdcore-nms-k8s-operator/issues


### PR DESCRIPTION
# Description

This adds a simple change to the description to bump the OCI image with the fixed documentation links. This is required because the beta release currently has bad links to the documentation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library