### PR TITLE
fix: change Pydantic version from 2.x to 1.x

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,6 @@ jsonschema
 jinja2
 juju
 ops
-pydantic
+pydantic<2
 pytest-interface-tester
 cosl

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile requirements.in
 #
-annotated-types==0.6.0
-    # via pydantic
 attrs==23.2.0
     # via
     #   jsonschema
@@ -84,12 +82,10 @@ pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
-pydantic==2.6.4
+pydantic==1.10.17
     # via
     #   -r requirements.in
     #   pytest-interface-tester
-pydantic-core==2.16.3
-    # via pydantic
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -148,7 +144,6 @@ typing-extensions==4.10.0
     # via
     #   cosl
     #   pydantic
-    #   pydantic-core
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,25 +7,35 @@
 asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 cachetools==5.3.3
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 certifi==2024.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 codespell==2.3.0
     # via -r test-requirements.in
 coverage[toml]==7.5.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
@@ -33,13 +43,21 @@ decorator==5.1.1
 executing==2.0.1
     # via stack-data
 google-auth==2.28.1
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 hvac==2.1.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 idna==3.7
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.2
@@ -47,73 +65,101 @@ ipython==8.22.2
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.5.0.0
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-operator
 kubernetes==29.0.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 macaroonbakery==1.3.4
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
 mypy==1.10.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
+    #   -c requirements.txt
     #   mypy
     #   typing-inspect
 oauthlib==3.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests-oauthlib
 packaging==23.2
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 parso==0.8.3
     # via jedi
 pexpect==4.9.0
     # via ipython
 pluggy==1.5.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.3
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
 pyasn1==0.5.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.3.0
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 pycparser==2.21
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 pynacl==1.5.0
     # via
+    #   -c requirements.txt
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
 pyrfc3339==1.1
     # via
+    #   -c requirements.txt
     #   juju
     #   macaroonbakery
 pytest==8.2.2
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -124,29 +170,40 @@ pytest-asyncio==0.21.2
 pytest-operator==0.35.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 pytz==2024.1
-    # via pyrfc3339
+    # via
+    #   -c requirements.txt
+    #   pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
 requests==2.32.3
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
 requests-oauthlib==1.3.1
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 rsa==4.9
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 ruff==0.4.10
     # via -r test-requirements.in
 six==1.16.0
     # via
+    #   -c requirements.txt
     #   asttokens
     #   kubernetes
     #   macaroonbakery
@@ -155,7 +212,9 @@ six==1.16.0
 stack-data==0.6.3
     # via ipython
 toposort==1.10
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 traitlets==5.14.1
     # via
     #   ipython
@@ -168,17 +227,25 @@ types-toml==0.10.8.20240310
     # via -r test-requirements.in
 typing-extensions==4.10.0
     # via
+    #   -c requirements.txt
     #   mypy
     #   typing-inspect
 typing-inspect==0.9.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 urllib3==2.2.1
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju


### PR DESCRIPTION
# Description

Pin Pydantic version < 2
Fixes the integration test issues because of validation like https://github.com/canonical/sdcore-nms-k8s-operator/actions/runs/9752751782/job/26916826038?pr=228

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library