### PR TITLE
fix: traefik integration test

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -60,6 +60,7 @@ async def deploy_traefik(ops_test: OpsTest):
     )
 
 async def configure_traefik(ops_test: OpsTest, traefik_ip: str) ->  None:
+    assert ops_test.model
     await ops_test.model.applications[TRAEFIK_CHARM_NAME].set_config(
         {
             "external_hostname": f"{traefik_ip}.nip.io",

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -59,6 +59,7 @@ async def deploy_traefik(ops_test: OpsTest):
         trust=True,
     )
 
+
 async def configure_traefik(ops_test: OpsTest, traefik_ip: str) ->  None:
     assert ops_test.model
     await ops_test.model.applications[TRAEFIK_CHARM_NAME].set_config(
@@ -72,6 +73,7 @@ async def configure_traefik(ops_test: OpsTest, traefik_ip: str) ->  None:
         status="active",
         timeout=TIMEOUT,
     )
+
 
 @pytest.mark.abort_on_fail
 async def deploy_sdcore_upf(ops_test: OpsTest):
@@ -131,7 +133,7 @@ async def deploy_grafana_agent(ops_test: OpsTest):
     )
 
 
-async def get_traefik_proxied_endpoints(ops_test: OpsTest):
+async def get_traefik_proxied_endpoints(ops_test: OpsTest) -> dict:
     """Retrieve the endpoints by using Traefik's `show-proxied-endpoints` action."""
     assert ops_test.model
     traefik = ops_test.model.applications[TRAEFIK_CHARM_NAME]

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -131,7 +131,7 @@ async def deploy_grafana_agent(ops_test: OpsTest):
     )
 
 
-async def get_traefik_proxied_endpoints(ops_test: OpsTest) -> str:
+async def get_traefik_proxied_endpoints(ops_test: OpsTest):
     """Retrieve the endpoints by using Traefik's `show-proxied-endpoints` action."""
     assert ops_test.model
     traefik = ops_test.model.applications[TRAEFIK_CHARM_NAME]


### PR DESCRIPTION
## Description
This is a workaround for https://github.com/canonical/traefik-k8s-operator/issues/361

A pydantic exception is raised when whe set to `subdomain` the routing_mode in traefik.
We need to add `nip.io` at the end of the external_hostname.

## The Integration Test

- Deploy traefik charm
- Wait for it to be idle
- Extract the traefik load balancer address using the `show-proxied-endpoints` action
- Configure the traefik charm 
```
            "external_hostname": f"{traefik_ip}.nip.io",
            "routing_mode": "subdomain"
```
- Obtain the NMS URL using the `show-proxied-endpoints` action. The URL looks like this:  `http://<model-name><nms-charm-name><traefik_ip>.nip.io/`
- Reach the NMS UI

There was a change in the Traefik charm:

### Before
The traefik-charm's public address is the load balancer external ip
![image](https://github.com/canonical/sdcore-nms-k8s-operator/assets/10354025/a0e74f05-83c6-4972-a4ec-fce3d1e4394f)

### Now
The load balancer external ip is shown in the traefik's status message field and it is different from the traefik-charm's public address
`$ juju status`

![image](https://github.com/canonical/sdcore-nms-k8s-operator/assets/10354025/3597888e-b02b-4f75-a9dd-fd965fcc09f7)
`$ microk8s kubectl get svc -n <namespace>`

![image](https://github.com/canonical/sdcore-nms-k8s-operator/assets/10354025/4ab0d30d-52c9-48dc-bd20-5e93051d0715)

so we can no longer use the public address of the traefik charm to reach the NMS UI.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library