### PR TITLE
fix: sdcore_config library ID

### DIFF
--- a/lib/charms/sdcore_nms_k8s/v0/sdcore_config.py
+++ b/lib/charms/sdcore_nms_k8s/v0/sdcore_config.py
@@ -113,7 +113,7 @@ from ops.model import Relation
 from pydantic import BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "9be8b7188c864ee9a180125bea4f8d36"
+LIBID = "87b8ff625f5544ad9985552df3fb6b6b"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0


### PR DESCRIPTION
# Description

By mistake I published the `sdcore_config` library as `sdcore_webui`. This PR fixes it.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library