### PR TITLE
fix: provide the valid service name in the sdcore_config relation data

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -43,7 +43,7 @@ AUTH_DATABASE_NAME = "authentication"
 COMMON_DATABASE_NAME = "free5gc"
 GRPC_PORT = 9876
 WEBUI_URL_PORT = 5000
-WEBUI_SERVICE_NAME = "webui"
+SDCORE_CONFIG_SERVICE_NAME = "nms"
 
 
 def _get_pod_ip() -> Optional[str]:
@@ -219,7 +219,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
             return
         if not self._is_nms_service_running():
             return
-        self._sdcore_config.set_webui_url_in_all_relations(webui_url=self._webui_config_url)
+        self._sdcore_config.set_webui_url_in_all_relations(webui_url=self._sdcore_config_endpoint_url)
 
     def _configure_workload(self):
         desired_config_file = self._generate_webui_config_file()
@@ -370,8 +370,8 @@ class SDCoreNMSOperatorCharm(CharmBase):
         self._webui.set_url(f"http://{self._webui_endpoint}")
 
     @property
-    def _webui_config_url(self) -> str:
-        return f"{WEBUI_SERVICE_NAME}:{GRPC_PORT}"
+    def _sdcore_config_endpoint_url(self) -> str:
+        return f"{SDCORE_CONFIG_SERVICE_NAME}:{GRPC_PORT}"
 
     @property
     def _webui_endpoint(self) -> str:

--- a/tests/unit/test_charm_workload_configuration.py
+++ b/tests/unit/test_charm_workload_configuration.py
@@ -175,8 +175,8 @@ class TestCharmWorkloadConfiguration(NMSUnitTestFixtures):
         relation_id_2 = self.harness.add_relation(SDCORE_CONFIG_RELATION_NAME, "requirer2")
         self.harness.add_relation_unit(relation_id=relation_id_2, remote_unit_name="requirer2")
         calls = [
-            call.emit(webui_url="webui:9876"),
-            call.emit(webui_url="webui:9876"),
+            call.emit(webui_url="nms:9876"),
+            call.emit(webui_url="nms:9876"),
         ]
         self.mock_set_webui_url_in_all_relations.assert_has_calls(calls)
 


### PR DESCRIPTION
# Description

The webui_url which is provided in sdcore_config relation was unreachable. Hence, this PR aims to fix this issue by providing a valid endpoint.
Fixes https://github.com/canonical/sdcore-nms-k8s-operator/issues/285

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library