### PR TITLE
fix: nms grcp address

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ sudo microk8s enable hostpath-storage
 
 Install Juju and bootstrap a controller on the MicroK8S instance:
 ```shell
-sudo snap install juju --channel=3.1/stable
+sudo snap install juju --channel=3.4/stable
 juju bootstrap microk8s
 ```
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -43,7 +43,6 @@ AUTH_DATABASE_NAME = "authentication"
 COMMON_DATABASE_NAME = "free5gc"
 GRPC_PORT = 9876
 WEBUI_URL_PORT = 5000
-WEBUI_SERVICE_NAME = "webui"
 
 
 def _get_pod_ip() -> Optional[str]:
@@ -371,7 +370,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
 
     @property
     def _webui_config_url(self) -> str:
-        return f"{WEBUI_SERVICE_NAME}:{GRPC_PORT}"
+        return f"{self.app.name}:{GRPC_PORT}"
 
     @property
     def _webui_endpoint(self) -> str:

--- a/tests/unit/test_charm_workload_configuration.py
+++ b/tests/unit/test_charm_workload_configuration.py
@@ -175,8 +175,8 @@ class TestCharmWorkloadConfiguration(NMSUnitTestFixtures):
         relation_id_2 = self.harness.add_relation(SDCORE_CONFIG_RELATION_NAME, "requirer2")
         self.harness.add_relation_unit(relation_id=relation_id_2, remote_unit_name="requirer2")
         calls = [
-            call.emit(webui_url="webui:9876"),
-            call.emit(webui_url="webui:9876"),
+            call.emit(webui_url="sdcore-nms-k8s:9876"),
+            call.emit(webui_url="sdcore-nms-k8s:9876"),
         ]
         self.mock_set_webui_url_in_all_relations.assert_has_calls(calls)
 


### PR DESCRIPTION
# Description

This PR set the webui URL in the sdcore_config relation to `{application_name}:5000`

Fixes https://github.com/canonical/sdcore-nms-k8s-operator/issues.
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library