### PR TITLE
chore: restore storage size to 5M

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,7 +30,7 @@ assumes:
 storage:
   config:
     type: filesystem
-    minimum-size: 1M
+    minimum-size: 5M
 
 requires:
   ingress:


### PR DESCRIPTION
# Description

This PR aims to restore the storage size of `config` filesystem to 5M, after it was decreased to 1M. This modification is necessary to allow a seamless upgrade from Aether SD-Core 1.4 to 1.5, as Juju does not allow in-place upgrade of charms if there is a change in the storage definition

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library