### PR TITLE
chore: Dummy change to re-publish NMS charm with new Rock image

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -111,8 +111,8 @@ class SDCoreNMSOperatorCharm(CharmBase):
             logger.info(f"Waiting for `{SDCORE_MANAGEMENT_RELATION_NAME}` relation to be created")
             return
         if not self._sdcore_management.management_url:
-            event.add_status(WaitingStatus("Waiting for webui management URL to be available"))
-            logger.info("Waiting for webui management URL to be available")
+            event.add_status(WaitingStatus("Waiting for Webui management URL to be available"))
+            logger.info("Waiting for Webui management URL to be available")
             return
         if not self._container.exists(path=CONFIG_DIR_PATH):
             event.add_status(WaitingStatus("Waiting for storage to be attached"))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -79,7 +79,7 @@ class TestCharm(unittest.TestCase):
         self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
-            WaitingStatus("Waiting for webui management URL to be available"),
+            WaitingStatus("Waiting for Webui management URL to be available"),
         )
 
     def test_given_management_url_available_when_pebble_ready_then_status_is_active(self):


### PR DESCRIPTION
# Description

A new Rock image from branch sdcore-nms 1.4 is created. This PR publishes the charm with this new image which has version 0.2.0.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library