### PR TITLE
chore: centralize HTTP calls in nms client

### DIFF
--- a/src/nms.py
+++ b/src/nms.py
@@ -39,14 +39,14 @@ class Upf:
 class CreateGnbParams:
     """Parameters to create a gNB."""
 
-    tac: int
+    tac: str
 
 
 @dataclass
 class CreateUPFParams:
     """Parameters to create a UPF."""
 
-    port: int
+    port: str
 
 
 class NMS:
@@ -66,7 +66,6 @@ class NMS:
         """Make an HTTP request and handle common error patterns."""
         headers = JSON_HEADER
         url = f"{self.url}{endpoint}"
-        logger.info("Request: %s %s", method, url)
         try:
             response = requests.request(
                 method=method,
@@ -74,8 +73,6 @@ class NMS:
                 headers=headers,
                 json=data,
             )
-            logger.info("Raw response: %s", response.text)
-            logger.info("Response code: %s", response.status_code)
         except requests.RequestException as e:
             logger.error("HTTP request failed: %s", e)
             return None
@@ -94,8 +91,7 @@ class NMS:
             json_response = response.json()
         except json.JSONDecodeError:
             return None
-        logger.info("JSON Response: %s", json_response)
-        return response
+        return json_response
 
     def list_gnbs(self) -> List[GnodeB]:
         """List gNBs from the NMS inventory."""
@@ -112,7 +108,7 @@ class NMS:
 
     def create_gnb(self, name: str, tac: int) -> None:
         """Create a gNB in the NMS inventory."""
-        create_gnb_params = CreateGnbParams(tac=tac)
+        create_gnb_params = CreateGnbParams(tac=str(tac))
         self._make_request("POST", f"/{GNB_CONFIG_URL}/{name}", data=asdict(create_gnb_params))
         logger.info("gNB %s created in NMS", name)
 
@@ -136,7 +132,7 @@ class NMS:
 
     def create_upf(self, hostname: str, port: int) -> None:
         """Create a UPF in the NMS inventory."""
-        create_upf_params = CreateUPFParams(port=port)
+        create_upf_params = CreateUPFParams(port=str(port))
         self._make_request("POST", f"/{UPF_CONFIG_URL}/{hostname}", data=asdict(create_upf_params))
         logger.info("UPF %s created in NMS", hostname)
 

--- a/src/nms.py
+++ b/src/nms.py
@@ -68,12 +68,14 @@ class NMS:
         url = f"{self.url}{endpoint}"
         logger.info("Request: %s %s", method, url)
         try:
-            req = requests.request(
+            response = requests.request(
                 method=method,
                 url=url,
                 headers=headers,
                 json=data,
             )
+            logger.info("Raw response: %s", response.text)
+            logger.info("Response code: %s", response.status_code)
         except requests.RequestException as e:
             logger.error("HTTP request failed: %s", e)
             return None
@@ -81,18 +83,18 @@ class NMS:
             logger.error("couldn't complete HTTP request: %s", e)
             return None
         try:
-            req.raise_for_status()
+            response.raise_for_status()
         except requests.HTTPError:
             logger.error(
                 "Request failed: code %s",
-                req.status_code,
+                response.status_code,
             )
             return None
         try:
-            response = req.json()
+            json_response = response.json()
         except json.JSONDecodeError:
             return None
-        logger.info("Response: %s", response)
+        logger.info("JSON Response: %s", json_response)
         return response
 
     def list_gnbs(self) -> List[GnodeB]:

--- a/src/nms.py
+++ b/src/nms.py
@@ -53,6 +53,8 @@ class NMS:
     """Handle NMS API calls."""
 
     def __init__(self, url: str):
+        if url.endswith("/"):
+            url = url[:-1]
         self.url = url
 
     def _make_request(

--- a/tests/unit/test_nms.py
+++ b/tests/unit/test_nms.py
@@ -128,7 +128,7 @@ class TestNMS:
             method="POST",
             url="some_url/config/v1/inventory/gnb/some.gnb.name",
             headers={"Content-Type": "application/json"},
-            json={"tac": 111},
+            json={"tac": "111"},
         )
 
     def test_given_a_valid_gnb_when_create_gnb_then_gnb_is_added_to_nms(self):
@@ -138,7 +138,7 @@ class TestNMS:
             method="POST",
             url="some_url/config/v1/inventory/gnb/some.gnb.name",
             headers={"Content-Type": "application/json"},
-            json={"tac": 111},
+            json={"tac": "111"},
         )
 
     @pytest.mark.parametrize(
@@ -266,7 +266,7 @@ class TestNMS:
             method="POST",
             url="some_url/config/v1/inventory/upf/some.upf.name",
             headers={"Content-Type": "application/json"},
-            json={"port": 111},
+            json={"port": "111"},
         )
 
     def test_given_a_valid_upf_when_create_upf_then_upf_is_added_to_nms(self):
@@ -276,7 +276,7 @@ class TestNMS:
             method="POST",
             url="some_url/config/v1/inventory/upf/some.upf.name",
             headers={"Content-Type": "application/json"},
-            json={"port": 22},
+            json={"port": "22"},
         )
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_nms.py
+++ b/tests/unit/test_nms.py
@@ -10,15 +10,11 @@ from nms import NMS, GnodeB, Upf
 
 
 class TestNMS:
-    patcher_request_get = patch("requests.get")
-    patcher_request_post = patch("requests.post")
-    patcher_request_delete = patch("requests.delete")
+    patcher_request = patch("requests.request")
 
     @pytest.fixture(autouse=True)
     def setUp(self, request):
-        self.mock_request_get = TestNMS.patcher_request_get.start()
-        self.mock_request_post = TestNMS.patcher_request_post.start()
-        self.mock_request_delete = TestNMS.patcher_request_delete.start()
+        self.mock_request = TestNMS.patcher_request.start()
         self.nms = NMS("some_url")
         request.addfinalizer(self.tearDown)
 
@@ -35,7 +31,7 @@ class TestNMS:
     @staticmethod
     def mock_response_with_connection_error_exception() -> MagicMock:
         mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = requests.exceptions.ConnectionError(
+        mock_response.raise_for_status.side_effect = requests.exceptions.RequestException(
             "Error connecting to NMS"
         )
         return mock_response
@@ -50,33 +46,34 @@ class TestNMS:
     @pytest.mark.parametrize(
         "exception",
         [
-            pytest.param(
-                mock_response_with_http_error_exception,
-            ),
-            pytest.param(
-                mock_response_with_connection_error_exception,
-            ),
+            requests.RequestException("Error connecting to NMS"),
+            OSError("Error connecting to NMS"),
         ],
     )
-    def test_given_exception_is_raised_when_get_gnb_then_an_empty_list_is_returned(
+    def test_given_exception_is_raised_when_list_gnbs_then_an_empty_list_is_returned(
         self, exception
     ):
-        self.mock_request_get.return_value = exception()
+        self.mock_request.side_effect = exception
 
         gnbs = self.nms.list_gnbs()
 
         assert gnbs == []
 
     def test_when_list_gnbs_then_gnb_url_is_used(self):
-        self.mock_request_get.return_value = self.mock_response_with_list([])
+        self.mock_request.return_value = self.mock_response_with_list([])
 
         self.nms.list_gnbs()
 
-        self.mock_request_get.assert_called_once_with("some_url/config/v1/inventory/gnb")
+        self.mock_request.assert_called_once_with(
+            method="GET",
+            url="some_url/config/v1/inventory/gnb",
+            headers={"Content-Type": "application/json"},
+            json=None,
+        )
 
     def test_given_nms_returns_a_gnb_list_when_list_gnbs_then_a_gnb_list_is_returned(self):
         nms_gnbs = [{"name": "some.gnb.name", "tac": "111"}]
-        self.mock_request_get.return_value = self.mock_response_with_list(nms_gnbs)
+        self.mock_request.return_value = self.mock_response_with_list(nms_gnbs)
 
         gnbs = self.nms.list_gnbs()
 
@@ -86,7 +83,7 @@ class TestNMS:
 
     def test_given_nms_returns_an_empty_list_when_list_gnbs_then_empty_list_is_returned(self):
         nms_gnbs = []
-        self.mock_request_get.return_value = self.mock_response_with_list(nms_gnbs)
+        self.mock_request.return_value = self.mock_response_with_list(nms_gnbs)
 
         gnbs = self.nms.list_gnbs()
 
@@ -98,7 +95,7 @@ class TestNMS:
             {"name": "a_gnb_name", "tac": "342"},
             {"name": "other.gnb_name", "tac": "99"},
         ]
-        self.mock_request_get.return_value = self.mock_response_with_list(nms_gnbs)
+        self.mock_request.return_value = self.mock_response_with_list(nms_gnbs)
 
         gnbs = self.nms.list_gnbs()
 
@@ -123,23 +120,25 @@ class TestNMS:
         ],
     )
     def test_given_exception_is_raised_when_create_gnb_then_exception_is_handled(self, exception):
-        self.mock_request_post.return_value = exception()
+        self.mock_request.side_effect = exception()
 
         self.nms.create_gnb(name="some.gnb.name", tac=111)
 
-        self.mock_request_post.assert_called_once_with(
-            "some_url/config/v1/inventory/gnb/some.gnb.name",
+        self.mock_request.assert_called_once_with(
+            method="POST",
+            url="some_url/config/v1/inventory/gnb/some.gnb.name",
             headers={"Content-Type": "application/json"},
-            json={"tac": "111"},
+            json={"tac": 111},
         )
 
     def test_given_a_valid_gnb_when_create_gnb_then_gnb_is_added_to_nms(self):
         self.nms.create_gnb(name="some.gnb.name", tac=111)
 
-        self.mock_request_post.assert_called_once_with(
-            "some_url/config/v1/inventory/gnb/some.gnb.name",
+        self.mock_request.assert_called_once_with(
+            method="POST",
+            url="some_url/config/v1/inventory/gnb/some.gnb.name",
             headers={"Content-Type": "application/json"},
-            json={"tac": "111"},
+            json={"tac": 111},
         )
 
     @pytest.mark.parametrize(
@@ -154,21 +153,27 @@ class TestNMS:
         ],
     )
     def test_given_exception_is_raised_when_delete_gnb_then_exceptions_is_handled(self, exception):
-        self.mock_request_delete.return_value = exception()
+        self.mock_request.side_effect = exception()
 
         gnb_name = "some.gnb.name"
         self.nms.delete_gnb(name=gnb_name)
 
-        self.mock_request_delete.assert_called_once_with(
-            f"some_url/config/v1/inventory/gnb/{gnb_name}"
+        self.mock_request.assert_called_once_with(
+            method="DELETE",
+            url="some_url/config/v1/inventory/gnb/some.gnb.name",
+            headers={"Content-Type": "application/json"},
+            json=None,
         )
 
     def test_given_valid_gnb_when_delete_gnb_then_gnb_is_successfully_deleted(self):
         gnb_name = "some.gnb.name"
         self.nms.delete_gnb(name=gnb_name)
 
-        self.mock_request_delete.assert_called_once_with(
-            f"some_url/config/v1/inventory/gnb/{gnb_name}"
+        self.mock_request.assert_called_once_with(
+            method="DELETE",
+            url="some_url/config/v1/inventory/gnb/some.gnb.name",
+            headers={"Content-Type": "application/json"},
+            json=None,
         )
 
     @pytest.mark.parametrize(
@@ -185,7 +190,7 @@ class TestNMS:
     def test_given_exception_is_raised_when_list_upfs_then_an_empty_list_is_returned(
         self, exception
     ):
-        self.mock_request_get.return_value = exception()
+        self.mock_request.side_effect = exception()
 
         upfs = self.nms.list_upfs()
 
@@ -193,15 +198,20 @@ class TestNMS:
 
     def test_when_list_upfs_then_upf_url_is_used(self):
         nms_upfs = []
-        self.mock_request_get.return_value = self.mock_response_with_list(nms_upfs)
+        self.mock_request.side_effect = self.mock_response_with_list(nms_upfs)
 
         self.nms.list_upfs()
 
-        self.mock_request_get.assert_called_once_with("some_url/config/v1/inventory/upf")
+        self.mock_request.assert_called_once_with(
+            method="GET",
+            url="some_url/config/v1/inventory/upf",
+            headers={"Content-Type": "application/json"},
+            json=None,
+        )
 
     def test_given_nms_returns_a_upf_list_when_list_upfs_then_a_upf_list_is_returned(self):
         nms_upfs = [{"hostname": "some.host.name", "port": "111"}]
-        self.mock_request_get.return_value = self.mock_response_with_list(nms_upfs)
+        self.mock_request.return_value = self.mock_response_with_list(nms_upfs)
 
         upfs = self.nms.list_upfs()
 
@@ -211,7 +221,7 @@ class TestNMS:
 
     def test_given_nms_returns_an_empty_list_when_list_upfs_then_empty_list_is_returned(self):
         nms_upfs = []
-        self.mock_request_get.return_value = self.mock_response_with_list(nms_upfs)
+        self.mock_request.return_value = self.mock_response_with_list(nms_upfs)
 
         upfs = self.nms.list_upfs()
 
@@ -223,7 +233,7 @@ class TestNMS:
             {"hostname": "a_host_name", "port": "342"},
             {"hostname": "other.host_name", "port": "99"},
         ]
-        self.mock_request_get.return_value = self.mock_response_with_list(nms_upfs)
+        self.mock_request.return_value = self.mock_response_with_list(nms_upfs)
 
         upfs = self.nms.list_upfs()
 
@@ -248,23 +258,25 @@ class TestNMS:
         ],
     )
     def test_given_exception_is_raised_when_create_upf_then_exception_is_handled(self, exception):
-        self.mock_request_post.return_value = exception()
+        self.mock_request.side_effect = exception()
 
         self.nms.create_upf(hostname="some.upf.name", port=111)
 
-        self.mock_request_post.assert_called_once_with(
-            "some_url/config/v1/inventory/upf/some.upf.name",
+        self.mock_request.assert_called_once_with(
+            method="POST",
+            url="some_url/config/v1/inventory/upf/some.upf.name",
             headers={"Content-Type": "application/json"},
-            json={"port": "111"},
+            json={"port": 111},
         )
 
     def test_given_a_valid_upf_when_create_upf_then_upf_is_added_to_nms(self):
         self.nms.create_upf(hostname="some.upf.name", port=22)
 
-        self.mock_request_post.assert_called_once_with(
-            "some_url/config/v1/inventory/upf/some.upf.name",
+        self.mock_request.assert_called_once_with(
+            method="POST",
+            url="some_url/config/v1/inventory/upf/some.upf.name",
             headers={"Content-Type": "application/json"},
-            json={"port": "22"},
+            json={"port": 22},
         )
 
     @pytest.mark.parametrize(
@@ -279,28 +291,35 @@ class TestNMS:
         ],
     )
     def test_given_exception_is_raised_when_delete_upf_then_exceptions_is_handled(self, exception):
-        self.mock_request_delete.return_value = exception()
+        self.mock_request.side_effect = exception()
 
         upf_name = "some.upf.name"
         self.nms.delete_upf(hostname=upf_name)
 
-        self.mock_request_delete.assert_called_once_with(
-            f"some_url/config/v1/inventory/upf/{upf_name}"
+        self.mock_request.assert_called_once_with(
+            method="DELETE",
+            url="some_url/config/v1/inventory/upf/some.upf.name",
+            headers={"Content-Type": "application/json"},
+            json=None,
         )
 
     def test_given_valid_upf_when_delete_upf_then_upf_is_successfully_deleted(self):
         upf_name = "some.upf.name"
+
         self.nms.delete_upf(hostname=upf_name)
 
-        self.mock_request_delete.assert_called_once_with(
-            f"some_url/config/v1/inventory/upf/{upf_name}"
+        self.mock_request.assert_called_once_with(
+            method="DELETE",
+            url="some_url/config/v1/inventory/upf/some.upf.name",
+            headers={"Content-Type": "application/json"},
+            json=None,
         )
 
     @pytest.mark.parametrize(
         "gnb",
         [
             pytest.param(
-                {"hostname": "some.gnb.name", "tac": "111"},
+                {"tac": "111"},
                 id="missing_name_parameter",
             ),
             pytest.param(
@@ -315,7 +334,7 @@ class TestNMS:
     )
     def test_given_nms_returns_an_invalid_gnb_when_list_gnbs_then_gnb_is_not_returned(self, gnb):
         nms_gnbs = [gnb]
-        self.mock_request_get.return_value = self.mock_response_with_list(nms_gnbs)
+        self.mock_request.return_value = self.mock_response_with_list(nms_gnbs)
 
         gnbs = self.nms.list_gnbs()
 
@@ -325,11 +344,11 @@ class TestNMS:
         "upf",
         [
             pytest.param(
-                {"name": "some.host.name", "port": "111"},
+                {"port": "111"},
                 id="missing_hostname_parameter",
             ),
             pytest.param(
-                {"hostname": "some.host.name", "tac": "111"},
+                {"hostname": "some.host.name"},
                 id="missing_port_parameter",
             ),
             pytest.param(
@@ -340,7 +359,7 @@ class TestNMS:
     )
     def test_given_nms_returns_an_invalid_upf_when_list_upfs_then_upf_is_not_returned(self, upf):
         nms_upfs = [upf]
-        self.mock_request_get.return_value = self.mock_response_with_list(nms_upfs)
+        self.mock_request.return_value = self.mock_response_with_list(nms_upfs)
 
         upfs = self.nms.list_upfs()
 


### PR DESCRIPTION
# Description

Here we centralize http calls into a `make_request` call. This allows for this client to scale as we will soon be adding a couple more methods to handle authentication. 

This is purely an implementation detail type issue where the user of this client is not impacted.

## Context

 I'm going through a couple of quality changes in the context of adding authentication support
- [x] Rename Webui to NMS
  - #357 
- [x] Improve NMS client method signatures
  - #357 
- [ ] Use common handler for HTTP request calls
  - #358 
- [ ] Add authentication support

I was going to initially bundle all of these together but I felt it was going to be easier to review if we separate quality improvements from features.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library