### PR TITLE
fix: use a valid endpoint to validate auth token

### DIFF
--- a/src/nms.py
+++ b/src/nms.py
@@ -161,7 +161,7 @@ class NMS:
 
     def token_is_valid(self, token: str) -> bool:
         """Return if the token is still valid by attempting to connect to an endpoint."""
-        response = self._make_request("GET", f"/{ACCOUNTS_URL}/me", token=token)
+        response = self._make_request("GET", f"/{ACCOUNTS_URL}", token=token)
         return response is not None
 
     def get_status(self) -> StatusResponse | None:


### PR DESCRIPTION
# Description

`config/v1/account/me` endpoint was used to validate token. This endpoint does not exist in the webui so we were getting lots of error logs. Also, the token secret was unnecessarily updated.
```
unit-sdcore-nms-k8s-0: 12:05:25 ERROR unit.sdcore-nms-k8s/0.juju-log Request failed: code 404
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library