### PR TITLE
fix: stabilize integration tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ juju deploy sdcore-nms-k8s --channel=1.5/edge
 juju deploy traefik-k8s --trust --config external_hostname=<your hostname> --config routing_mode=subdomain
 juju deploy self-signed-certificates
 juju deploy sdcore-upf-k8s --channel=1.5/edge --trust
-juju deploy mongodb-k8s --trust --channel=6/beta
+juju deploy mongodb-k8s --trust --channel=6/stable
 juju deploy sdcore-gnbsim-k8s --trust --channel=1.5/edge
 juju deploy grafana-agent-k8s --trust --channel=latest/stable
 juju integrate sdcore-nms-k8s:certificates self-signed-certificates:certificates

--- a/src/charm.py
+++ b/src/charm.py
@@ -311,16 +311,18 @@ class SDCoreNMSOperatorCharm(CharmBase):
         """Create the first admin and store the credentials in a secret if it does not exist."""
         if not self._nms.is_api_available():
             return
-        if not self._nms.is_initialized():
+        account = self._get_admin_account()
+        if not account:
             username = _generate_username()
             password = _generate_password()
-            self._nms.create_first_user(username, password)
             account = LoginSecret(username, password, None)
             self.app.add_secret(
                 label=NMS_LOGIN_SECRET_LABEL,
                 content=account.to_dict(),
             )
             logger.info("admin account details saved to secrets.")
+        if not self._nms.is_initialized():
+            self._nms.create_first_user(account.username, account.password)
 
     def _get_admin_account(self) -> LoginSecret | None:
         """Get the NMS admin user credentials from secrets.

--- a/src/nms.py
+++ b/src/nms.py
@@ -67,13 +67,6 @@ class CreateUserParams:
 
 
 @dataclass
-class CreateUserResponse:
-    """Response from NMS when creating a user."""
-
-    id: int
-
-
-@dataclass
 class CreateGnbParams:
     """Parameters to create a gNB."""
 
@@ -225,13 +218,9 @@ class NMS:
         self._make_request("DELETE", f"/{UPF_CONFIG_URL}/{hostname}", token=token)
         logger.info("UPF %s deleted from NMS", hostname)
 
-    def create_first_user(self, username: str, password: str) -> CreateUserResponse | None:
+    def create_first_user(self, username: str, password: str) -> None:
         """Create the first admin user."""
         logger.info("Creating first user %s", username)
         create_user_params = CreateUserParams(username=username, password=password)
-        response = self._make_request("POST", f"/{ACCOUNTS_URL}", data=asdict(create_user_params))
-        if response:
-            return CreateUserResponse(
-                id=response.get("id"),
-            )
-        return None
+        self._make_request("POST", f"/{ACCOUNTS_URL}", data=asdict(create_user_params))
+

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -310,29 +310,6 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, deploy):
 
 
 @pytest.mark.abort_on_fail
-async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, deploy):
-    assert ops_test.model
-    await ops_test.model.remove_application(DATABASE_APP_NAME, block_until_done=True)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=TIMEOUT)
-
-
-@pytest.mark.abort_on_fail
-async def test_restore_database_and_wait_for_active_status(ops_test: OpsTest, deploy):
-    assert ops_test.model
-    await _deploy_database(ops_test)
-    await ops_test.model.integrate(
-        relation1=f"{APP_NAME}:{COMMON_DATABASE_RELATION_NAME}", relation2=DATABASE_APP_NAME
-    )
-    await ops_test.model.integrate(
-        relation1=f"{APP_NAME}:{AUTH_DATABASE_RELATION_NAME}", relation2=DATABASE_APP_NAME
-    )
-    await ops_test.model.integrate(
-        relation1=f"{APP_NAME}:{WEBUI_DATABASE_RELATION_NAME}", relation2=DATABASE_APP_NAME
-    )
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
-
-
-@pytest.mark.abort_on_fail
 async def test_given_related_to_traefik_when_fetch_ui_then_returns_html_content(
     ops_test: OpsTest, deploy
 ):
@@ -418,6 +395,29 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, deploy)
     assert ops_test.model
     await _deploy_self_signed_certificates(ops_test)
     await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_PROVIDER_CHARM_NAME)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(DATABASE_APP_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=TIMEOUT)
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_database_and_wait_for_active_status(ops_test: OpsTest, deploy):
+    assert ops_test.model
+    await _deploy_database(ops_test)
+    await ops_test.model.integrate(
+        relation1=f"{APP_NAME}:{COMMON_DATABASE_RELATION_NAME}", relation2=DATABASE_APP_NAME
+    )
+    await ops_test.model.integrate(
+        relation1=f"{APP_NAME}:{AUTH_DATABASE_RELATION_NAME}", relation2=DATABASE_APP_NAME
+    )
+    await ops_test.model.integrate(
+        relation1=f"{APP_NAME}:{WEBUI_DATABASE_RELATION_NAME}", relation2=DATABASE_APP_NAME
+    )
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -27,7 +27,7 @@ AMF_CHARM_NAME = "sdcore-amf-k8s"
 AMF_CHARM_CHANNEL = "1.5/edge"
 APP_NAME = METADATA["name"]
 DATABASE_APP_NAME = "mongodb-k8s"
-DATABASE_APP_CHANNEL = "6/beta"
+DATABASE_APP_CHANNEL = "6/stable"
 COMMON_DATABASE_RELATION_NAME = "common_database"
 AUTH_DATABASE_RELATION_NAME = "auth_database"
 WEBUI_DATABASE_RELATION_NAME = "webui_database"
@@ -309,9 +309,6 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, deploy):
     )
 
 
-@pytest.mark.skip(
-    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
-)
 @pytest.mark.abort_on_fail
 async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, deploy):
     assert ops_test.model
@@ -319,9 +316,6 @@ async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, de
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=TIMEOUT)
 
 
-@pytest.mark.skip(
-    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
-)
 @pytest.mark.abort_on_fail
 async def test_restore_database_and_wait_for_active_status(ops_test: OpsTest, deploy):
     assert ops_test.model

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -254,13 +254,13 @@ async def deploy(ops_test: OpsTest, request):
         trust=True,
     )
     await _deploy_database(ops_test)
-    await _deploy_grafana_agent(ops_test)
     await _deploy_self_signed_certificates(ops_test)
-    await _deploy_traefik(ops_test)
     await _deploy_nrf(ops_test)
     await _deploy_sdcore_gnbsim(ops_test)
     await _deploy_amf(ops_test)
     await _deploy_sdcore_upf(ops_test)
+    await _deploy_grafana_agent(ops_test)
+    await _deploy_traefik(ops_test)
 
 
 @pytest.mark.abort_on_fail
@@ -303,7 +303,7 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, deploy):
         relation1=f"{APP_NAME}:ingress", relation2=f"{TRAEFIK_CHARM_NAME}:ingress"
     )
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, TRAEFIK_CHARM_NAME],
+        apps=[APP_NAME, TRAEFIK_CHARM_NAME, GNBSIM_CHARM_NAME],
         status="active",
         timeout=TIMEOUT,
     )

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -725,6 +725,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             self.ctx.run(self.ctx.on.relation_broken(relation), state_in)
 
     def test_given_login_secret_doesnt_exist_when_configure_then_login_secret_created(self):
+        self.mock_is_api_available.return_value = True
+        self.mock_is_initialized.return_value = False
         self.mock_nms_login.return_value = LoginResponse(token="test-token")
         with tempfile.TemporaryDirectory() as tempdir:
             common_database_relation = scenario.Relation(


### PR DESCRIPTION
# Description

Integration tests are unstable. It seem like we try to reach the list of gnbs before the gnbsim was added to the inventory due to a failed log in attempt.

This PR:
- Sets the mongodb channel to 6/stable
- Fixes the failed log in attempt. 
    - A `CreateUserResponse` including an ID was expected from the POST user account endpoint, but the webui returns None after user successful creation. `CreateUserResponse` was removed.
    - This fix removes the log errors about the first user creation and leads to immediate login after user creation.
- Restores integration tests related status blocked when DB is removed (https://github.com/canonical/mongodb-k8s-operator/issues/218 seems fixed in `6/stable`)
- Separate `_get_or_create_admin_account` into 2 functions to separate their responsibility. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library