### PR TITLE
chore: Configures renovate to cover v1.5; adds v1.5 scheduled CI runs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,17 +20,22 @@
   "packageRules": [
     // Later rules override earlier rules
     {
+      "matchBaseBranches": ["main", "v*"],
       "matchManagers": ["pep621"],
       "rangeStrategy": "bump",
       "groupName": "Python dependencies"
     },
     {
+      "matchBaseBranches": ["main", "v*"],
       "matchManagers": ["github-actions"],
       "groupName": "GitHub actions"
     },
     {
+      "matchBaseBranches": ["main", "v*"],
       "matchManagers": ["terraform"],
       "groupName": "Terraform"
     },
   ],
+  // Bumping "pytest-asyncio" over 0.23 breaks the integration tests
+  "ignoreDeps": ["pytest-asyncio"]
 }

--- a/.github/workflows/1_5_scheduled_runs.yaml
+++ b/.github/workflows/1_5_scheduled_runs.yaml
@@ -1,0 +1,57 @@
+name: Release 1.5 scheduled CI
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'
+
+jobs:
+  codeql:
+    name: CodeQL Analysis
+    uses: canonical/sdcore-github-workflows/.github/workflows/codeql-analysis.yml@v2.2.0
+    with:
+      branch-name: "v1.5"
+
+  lint-report:
+    uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@v2.2.0
+    with:
+      branch-name: "v1.5"
+
+  terraform-check:
+    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v2.2.0
+    with:
+      branch-name: "v1.5"
+
+  static-analysis:
+    uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@v2.2.0
+    with:
+      branch-name: "v1.5"
+
+  unit-tests-with-coverage:
+    uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@v2.2.0
+    with:
+      branch-name: "v1.5"
+
+  build:
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+    uses: canonical/sdcore-github-workflows/.github/workflows/build.yaml@v2.2.0
+    with:
+      branch-name: "v1.5"
+    secrets: inherit
+
+  integration-test:
+    needs:
+      - build
+    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@v2.2.0
+    with:
+      branch-name: "v1.5"
+      enable-metallb: true
+
+  update-lib:
+    name: Check libraries
+    uses: canonical/sdcore-github-workflows/.github/workflows/update-libs.yaml@v2.2.0
+    with:
+      branch-name: "v1.5"
+    secrets: inherit


### PR DESCRIPTION
# Description

- Configures renovate to cover `v1.5`
- Adds `v1.5` scheduled CI runs

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library