### PR TITLE
chore: Ignores only minor versions of pytest-asyncio

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,12 @@
       "groupName": "Python dependencies"
     },
     {
+      // Bumping "pytest-asyncio" over 0.23 breaks the integration tests
+      "matchPackageNames": ["pytest-asyncio"],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
+    },
+    {
       "matchBaseBranches": ["main", "v*"],
       "matchManagers": ["github-actions"],
       "groupName": "GitHub actions"
@@ -36,6 +42,4 @@
       "groupName": "Terraform"
     },
   ],
-  // Bumping "pytest-asyncio" over 0.23 breaks the integration tests
-  "ignoreDeps": ["pytest-asyncio"]
 }


### PR DESCRIPTION
# Description

Ignores only minor versions of `pytest-asyncio`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library