### PR TITLE
fix: prevent failure when updating relation data during relation-departed events

### DIFF
--- a/lib/charms/sdcore_nms_k8s/v0/sdcore_config.py
+++ b/lib/charms/sdcore_nms_k8s/v0/sdcore_config.py
@@ -109,7 +109,7 @@ from typing import Optional
 from interface_tester.schema_base import DataBagSchema
 from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
 from ops.framework import EventBase, EventSource, Handle, Object
-from ops.model import Relation
+from ops.model import ModelError, Relation
 from pydantic import BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
@@ -336,4 +336,7 @@ class SdcoreConfigProvides(Object):
             raise RuntimeError(f"Relation {self.relation_name} not created yet.")
 
         for relation in relations:
-            relation.data[self.charm.app].update({"webui_url": webui_url})
+            try:
+                relation.data[self.charm.app].update({"webui_url": webui_url})
+            except ModelError as exc:
+                logger.error("Error updating the relation data: %s", str(exc))


### PR DESCRIPTION
This PR aims to mitigate #402 by catching the `ModelError` exception if the `sdcore_config` relation data is updated during a `relation-departed` event.
See https://github.com/canonical/operator/issues/1109 for the ongoing in-depth discussion.

Note: the issue cannot be reproduced by emitting the `relation-departed` event using scenario, so unit test cannot be added.

# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library