### PR TITLE
fix: use correct library name

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,7 +93,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@v2.3.0
     with:
-      lib-name: "lib/charms/sdcore_nms_k8s/v0/sdcore_config"
+      lib-name: "charms/sdcore_nms_k8s/v0/sdcore_config"
     secrets: inherit
 
   fiveg-core-gnb-lib-needs-publishing:
@@ -117,5 +117,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@v2.3.0
     with:
-      lib-name: "lib/charms/sdcore_nms_k8s/v0/fiveg_core_gnb"
+      lib-name: "charms/sdcore_nms_k8s/v0/fiveg_core_gnb"
     secrets: inherit


### PR DESCRIPTION
# Description

This PR fixes the wrong library names in workflows, causing CI failures.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library