### PR TITLE
chore: bump sdcore_config library patch version

### DIFF
--- a/lib/charms/sdcore_nms_k8s/v0/sdcore_config.py
+++ b/lib/charms/sdcore_nms_k8s/v0/sdcore_config.py
@@ -120,7 +120,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

This PR bumps the patch version of `sdcore_config` library after #409.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library