### PR TITLE
fix: Casts SD from hex to int

### DIFF
--- a/src/nms.py
+++ b/src/nms.py
@@ -247,14 +247,18 @@ class NMS:
         return response
 
     def get_network_slice(self, slice_name: str, token: str) -> Optional[NetworkSlice]:
-        """Get NetworkSlice."""
+        """Get NetworkSlice.
+
+        The SD value received in the Network Slice configuration is a hex. In this function
+        we cast it to a human-readable integer.
+        """
         response = self._make_request("GET", f"/{NETWORK_SLICE_CONFIG_URL}/{slice_name}", token=token)  # noqa: E501
         if not response:
             return None
         mcc = response["site-info"]["plmn"]["mcc"]
         mnc = response["site-info"]["plmn"]["mnc"]
         sst = int(response["slice-id"]["sst"])
-        sd = int(response["slice-id"]["sd"])
+        sd = int(response["slice-id"]["sd"], 16)
         gnbs = [GnodeB(gnb["name"], gnb["tac"]) for gnb in response["site-info"]["gNodeBs"]]
 
         return NetworkSlice(mcc, mnc, sst, sd, gnbs)

--- a/tests/unit/test_nms.py
+++ b/tests/unit/test_nms.py
@@ -402,11 +402,12 @@ class TestNMS:
         test_mcc = "123"
         test_mnc = "89"
         test_sst = "321"
-        test_sd = "4321"
+        test_sd_hex = "4321"
+        test_sd_int = int(test_sd_hex, 16)
         test_gnb_name = "some.gnb.name"
         network_slice_json = {
             "slice-name": test_slice_name,
-            "slice-id": {"sst": test_sst, "sd": test_sd},
+            "slice-id": {"sst": test_sst, "sd": test_sd_hex},
             "site-info": {
                 "plmn": {"mcc": test_mcc, "mnc": test_mnc},
                 "gNodeBs": [{"name": test_gnb_name, "tac": 1}],
@@ -420,7 +421,7 @@ class TestNMS:
             test_mcc,
             test_mnc,
             int(test_sst),
-            int(test_sd),
+            test_sd_int,
             [GnodeB(name=test_gnb_name, tac=1, plmns=[])]
         )
 


### PR DESCRIPTION
# Description

Casts SD from hex to int
The SD value received in the Network Slice configuration is a hex, while the `fiveg_core_gnb` interface expects an int.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library