### PR TITLE
fix: use ubuntu@24.04 in TF modules

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,7 @@ resource "juju_application" "nms" {
     name     = "sdcore-nms-k8s"
     channel  = var.channel
     revision = var.revision
+    base     = var.base
   }
 
   config      = var.config

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,12 @@ variable "revision" {
   default     = null
 }
 
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "units" {
   description = "Number of units to deploy"
   type        = number

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -42,6 +42,7 @@ NRF_CHARM_CHANNEL = "1.5/edge"
 UPF_CHARM_NAME = "sdcore-upf-k8s"
 UPF_CHARM_CHANNEL = "1.5/edge"
 UPF_RELATION_NAME = "fiveg_n4"
+SDCORE_CHARMS_BASE = "ubuntu@24.04"
 TLS_PROVIDER_CHARM_NAME = "self-signed-certificates"
 TLS_PROVIDER_CHARM_CHANNEL = "latest/stable"
 TRAEFIK_CHARM_NAME = "traefik-k8s"
@@ -105,6 +106,7 @@ async def _deploy_sdcore_upf(ops_test: OpsTest):
         UPF_CHARM_NAME,
         application_name=UPF_CHARM_NAME,
         channel=UPF_CHARM_CHANNEL,
+        base=SDCORE_CHARMS_BASE,
         trust=True,
     )
 
@@ -115,6 +117,7 @@ async def _deploy_nrf(ops_test: OpsTest):
         NRF_CHARM_NAME,
         application_name=NRF_CHARM_NAME,
         channel=NRF_CHARM_CHANNEL,
+        base=SDCORE_CHARMS_BASE,
     )
     await ops_test.model.integrate(
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DATABASE_APP_NAME}"
@@ -128,6 +131,7 @@ async def _deploy_sdcore_gnbsim(ops_test: OpsTest):
         GNBSIM_CHARM_NAME,
         application_name=GNBSIM_CHARM_NAME,
         channel=GNBSIM_CHARM_CHANNEL,
+        base=SDCORE_CHARMS_BASE,
         trust=True,
     )
 
@@ -147,6 +151,7 @@ async def _deploy_amf(ops_test: OpsTest):
         AMF_CHARM_NAME,
         application_name=AMF_CHARM_NAME,
         channel=AMF_CHARM_CHANNEL,
+        base=SDCORE_CHARMS_BASE,
         trust=True,
     )
     await ops_test.model.integrate(relation1=AMF_CHARM_NAME, relation2=NRF_CHARM_NAME)


### PR DESCRIPTION
# Description

By default, Juju fetches charms with base matching the host OS. It means that when running Jammy, Juju won’t use latest charms, because we’ve changed the base to Noble.

Adding an optional (as per CC006) config param base will allow using Noble (base should be set to ubuntu@24.04) regardless of the host OS.

Enforcing Noble on a Juju model configuration level is not an option, because it breaks COS integration (COS charms are not available in ubuntu@24.04).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library