### PR TITLE
feat: update API change in webconsole to edit UPFs and gNBs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -459,12 +459,25 @@ class SDCoreNMSOperatorCharm(CharmBase):
             return
         nms_gnbs = self._nms.list_gnbs(token=login_details.token)
         integrated_gnbs = self._get_integrated_gnbs()
-        for gnb in nms_gnbs:
-            if gnb not in integrated_gnbs:
-                self._nms.delete_gnb(name=gnb.name, token=login_details.token)
-        for gnb in integrated_gnbs:
-            if gnb not in nms_gnbs:
-                self._nms.create_gnb(name=gnb.name, tac=gnb.tac, token=login_details.token)
+
+        nms_gnb_names = [gnb.name for gnb in nms_gnbs]
+        integration_gnb_names = [gnb.name for gnb in integrated_gnbs]
+
+        for nms_gnb in nms_gnbs:
+            if nms_gnb.name not in integration_gnb_names:
+                self._nms.delete_gnb(name=nms_gnb.name, token=login_details.token)
+
+        for intrated_gnb in integrated_gnbs:
+            if intrated_gnb.name in nms_gnb_names:
+                nms_gnb = next((gnb for gnb in nms_gnbs if gnb.name == intrated_gnb.name), None)
+                if nms_gnb and nms_gnb.tac != intrated_gnb.tac:
+                    self._nms.update_gnb(
+                        name=intrated_gnb.name, tac=intrated_gnb.tac, token=login_details.token
+                    )
+            else:
+                self._nms.create_gnb(
+                    name=intrated_gnb.name, tac=intrated_gnb.tac, token=login_details.token
+                )
 
     def _get_integrated_gnbs(self) -> List[GnodeB]:
         integrated_gnbs = []
@@ -484,13 +497,31 @@ class SDCoreNMSOperatorCharm(CharmBase):
             logger.info("Relation %s not available", FIVEG_N4_RELATION_NAME)
         nms_upfs = self._nms.list_upfs(token=login_details.token)
         relation_upfs = self._get_upf_config_from_relations()
-        for upf in nms_upfs:
-            if upf not in relation_upfs:
-                self._nms.delete_upf(hostname=upf.hostname, token=login_details.token)
-        for upf in relation_upfs:
-            if upf not in nms_upfs:
+
+        nms_hostnames = [upf.hostname for upf in nms_upfs]
+        relation_hostnames = [upf.hostname for upf in relation_upfs]
+
+        for nsm_upf in nms_upfs:
+            if nsm_upf.hostname not in relation_hostnames:
+                self._nms.delete_upf(hostname=nsm_upf.hostname, token=login_details.token)
+
+        for relation_upf in relation_upfs:
+            if relation_upf.hostname in nms_hostnames:
+                nms_upf = next(
+                    (upf for upf in nms_upfs if upf.hostname == relation_upf.hostname),
+                    None
+                )
+                if nms_upf and nms_upf.port != relation_upf.port:
+                    self._nms.update_upf(
+                        hostname=relation_upf.hostname,
+                        port=relation_upf.port,
+                        token=login_details.token
+                    )
+            else:
                 self._nms.create_upf(
-                    hostname=upf.hostname, port=upf.port, token=login_details.token
+                    hostname=relation_upf.hostname,
+                    port=relation_upf.port,
+                    token=login_details.token
                 )
 
     def _get_gnbs_config(self) -> List[GnodeB]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -467,16 +467,18 @@ class SDCoreNMSOperatorCharm(CharmBase):
             if nms_gnb.name not in integration_gnb_names:
                 self._nms.delete_gnb(name=nms_gnb.name, token=login_details.token)
 
-        for intrated_gnb in integrated_gnbs:
-            if intrated_gnb.name in nms_gnb_names:
-                nms_gnb = next((gnb for gnb in nms_gnbs if gnb.name == intrated_gnb.name), None)
-                if nms_gnb and nms_gnb.tac != intrated_gnb.tac:
+        for integrated_gnb in integrated_gnbs:
+            if integrated_gnb.name in nms_gnb_names:
+                nms_gnb = next((gnb for gnb in nms_gnbs if gnb.name == integrated_gnb.name), None)
+                if nms_gnb and nms_gnb.tac != integrated_gnb.tac:
                     self._nms.update_gnb(
-                        name=intrated_gnb.name, tac=intrated_gnb.tac, token=login_details.token
+                        name=integrated_gnb.name,
+                        tac=integrated_gnb.tac,
+                        token=login_details.token
                     )
             else:
                 self._nms.create_gnb(
-                    name=intrated_gnb.name, tac=intrated_gnb.tac, token=login_details.token
+                    name=integrated_gnb.name, tac=integrated_gnb.tac, token=login_details.token
                 )
 
     def _get_integrated_gnbs(self) -> List[GnodeB]:

--- a/src/nms.py
+++ b/src/nms.py
@@ -83,6 +83,12 @@ class CreateUserParams:
 @dataclass
 class CreateGnbParams:
     """Parameters to create a gNB."""
+    name: str
+    tac: str
+
+@dataclass
+class UpdateGnbParams:
+    """Parameters to update a gNB."""
 
     tac: str
 
@@ -90,6 +96,12 @@ class CreateGnbParams:
 @dataclass
 class CreateUPFParams:
     """Parameters to create a UPF."""
+    hostname: str
+    port: str
+
+@dataclass
+class UpdateUPFParams:
+    """Parameters to update a UPF."""
 
     port: str
 
@@ -196,9 +208,17 @@ class NMS:
 
     def create_gnb(self, name: str, tac: int, token: str) -> None:
         """Create a gNB in the NMS inventory."""
-        create_gnb_params = CreateGnbParams(tac=str(tac))
+        create_gnb_params = CreateGnbParams(name=name, tac=str(tac))
         self._make_request(
-            "PUT", f"/{GNB_CONFIG_URL}/{name}", data=asdict(create_gnb_params), token=token
+            "POST", f"/{GNB_CONFIG_URL}", data=asdict(create_gnb_params), token=token
+        )
+        logger.info("gNB %s created in NMS", name)
+
+    def update_gnb(self, name: str, tac: int, token: str) -> None:
+        """Update a gNB in the NMS inventory."""
+        update_gnb_params = UpdateGnbParams(tac=str(tac))
+        self._make_request(
+            "PUT", f"/{GNB_CONFIG_URL}/{name}", data=asdict(update_gnb_params), token=token
         )
         logger.info("gNB %s created in NMS", name)
 
@@ -222,11 +242,19 @@ class NMS:
 
     def create_upf(self, hostname: str, port: int, token: str) -> None:
         """Create a UPF in the NMS inventory."""
-        create_upf_params = CreateUPFParams(port=str(port))
+        create_upf_params = CreateUPFParams(hostname=hostname, port=str(port))
         self._make_request(
-            "PUT", f"/{UPF_CONFIG_URL}/{hostname}", data=asdict(create_upf_params), token=token
+            "POST", f"/{UPF_CONFIG_URL}", data=asdict(create_upf_params), token=token
         )
         logger.info("UPF %s created in NMS", hostname)
+
+    def update_upf(self, hostname: str, port: int, token: str) -> None:
+        """Update a UPF in the NMS inventory."""
+        update_upf_params = UpdateUPFParams(port=str(port))
+        self._make_request(
+            "PUT", f"/{UPF_CONFIG_URL}/{hostname}", data=asdict(update_upf_params), token=token
+        )
+        logger.info("UPF %s updated in NMS", hostname)
 
     def delete_upf(self, hostname: str, token: str) -> None:
         """Delete a UPF list from the NMS inventory."""

--- a/src/nms.py
+++ b/src/nms.py
@@ -198,7 +198,7 @@ class NMS:
         """Create a gNB in the NMS inventory."""
         create_gnb_params = CreateGnbParams(tac=str(tac))
         self._make_request(
-            "POST", f"/{GNB_CONFIG_URL}/{name}", data=asdict(create_gnb_params), token=token
+            "PUT", f"/{GNB_CONFIG_URL}/{name}", data=asdict(create_gnb_params), token=token
         )
         logger.info("gNB %s created in NMS", name)
 
@@ -224,7 +224,7 @@ class NMS:
         """Create a UPF in the NMS inventory."""
         create_upf_params = CreateUPFParams(port=str(port))
         self._make_request(
-            "POST", f"/{UPF_CONFIG_URL}/{hostname}", data=asdict(create_upf_params), token=token
+            "PUT", f"/{UPF_CONFIG_URL}/{hostname}", data=asdict(create_upf_params), token=token
         )
         logger.info("UPF %s created in NMS", hostname)
 

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -23,9 +23,11 @@ class BaseNMSUnitTestFixtures:
     patcher_nms_get_network_slice = patch("nms.NMS.get_network_slice")
     patcher_nms_list_gnbs = patch("nms.NMS.list_gnbs")
     patcher_nms_create_gnb = patch("nms.NMS.create_gnb")
+    patcher_nms_update_gnb = patch("nms.NMS.update_gnb")
     patcher_nms_delete_gnb = patch("nms.NMS.delete_gnb")
     patcher_nms_list_upfs = patch("nms.NMS.list_upfs")
     patcher_nms_create_upf = patch("nms.NMS.create_upf")
+    patcher_nms_update_upf = patch("nms.NMS.update_upf")
     patcher_nms_delete_upf = patch("nms.NMS.delete_upf")
 
     def common_setup(self):
@@ -42,9 +44,11 @@ class BaseNMSUnitTestFixtures:
         self.mock_get_network_slice = NMSUnitTestFixtures.patcher_nms_get_network_slice.start()
         self.mock_list_gnbs = NMSUnitTestFixtures.patcher_nms_list_gnbs.start()
         self.mock_create_gnb = NMSUnitTestFixtures.patcher_nms_create_gnb.start()
+        self.mock_update_gnb = NMSUnitTestFixtures.patcher_nms_update_gnb.start()
         self.mock_delete_gnb = NMSUnitTestFixtures.patcher_nms_delete_gnb.start()
         self.mock_list_upfs = NMSUnitTestFixtures.patcher_nms_list_upfs.start()
         self.mock_create_upf = NMSUnitTestFixtures.patcher_nms_create_upf.start()
+        self.mock_update_upf = NMSUnitTestFixtures.patcher_nms_update_upf.start()
         self.mock_delete_upf = NMSUnitTestFixtures.patcher_nms_delete_upf.start()
 
     @staticmethod

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -921,6 +921,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
 
             self.mock_create_gnb.assert_not_called()
             self.mock_create_upf.assert_not_called()
+            self.mock_update_gnb.assert_not_called()
+            self.mock_update_upf.assert_not_called()
             self.mock_delete_gnb.assert_not_called()
             self.mock_delete_upf.assert_not_called()
 
@@ -970,8 +972,10 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
             self.mock_create_gnb.assert_not_called()
+            self.mock_update_gnb.assert_not_called()
             self.mock_delete_gnb.assert_not_called()
             self.mock_create_upf.assert_not_called()
+            self.mock_update_gnb.assert_not_called()
             self.mock_delete_upf.assert_not_called()
 
     def test_given_mandatory_relations_when_pebble_ready_then_nms_upf_is_updated(
@@ -1066,6 +1070,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             self.mock_create_upf.assert_called_once_with(
                 hostname="some.host.name", port=1234, token="test-token"
             )
+            self.mock_update_upf.assert_not_called()
+            self.mock_delete_upf.assert_not_called()
 
     def test_given_mandatory_relations_when_pebble_ready_then_nms_gnb_is_updated(
         self,
@@ -1158,6 +1164,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             self.mock_create_gnb.assert_called_once_with(
                 name="some.gnb.name", tac=1, token="test-token"
             )
+            self.mock_update_gnb.assert_not_called()
+            self.mock_delete_gnb.assert_not_called()
 
     def test_given_multiple_n4_relations_when_pebble_ready_then_both_upfs_are_added_to_nms(
         self,
@@ -1253,6 +1261,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 call(hostname="some.host.name", port=1234, token="test-token"),
             ]
             self.mock_create_upf.assert_has_calls(calls, any_order=True)
+            self.mock_update_upf.assert_not_called()
+            self.mock_delete_upf.assert_not_called()
 
     def test_given_multiple_gnb_relations_when_pebble_ready_then_both_gnbs_are_added_to_nms(
         self,
@@ -1346,6 +1356,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 call(name="my_gnb", tac=1, token="test-token"),
             ]
             self.mock_create_gnb.assert_has_calls(calls, any_order=True)
+            self.mock_update_gnb.assert_not_called()
+            self.mock_delete_gnb.assert_not_called()
 
     def test_given_upf_exist_in_nms_and_relation_matches_when_pebble_ready_then_nms_upfs_are_not_updated(  # noqa: E501
         self,
@@ -1430,6 +1442,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
 
             self.mock_list_upfs.assert_called()
             self.mock_create_upf.assert_not_called()
+            self.mock_update_upf.assert_not_called()
+            self.mock_delete_upf.assert_not_called()
 
     def test_given_gnb_exist_in_nms_and_relation_matches_when_pebble_ready_then_nms_gnbs_are_not_updated(  # noqa: E501
         self,
@@ -1514,6 +1528,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
 
             self.mock_list_gnbs.assert_called()
             self.mock_create_gnb.assert_not_called()
+            self.mock_update_gnb.assert_not_called()
+            self.mock_delete_gnb.assert_not_called()
 
     def test_given_no_upf_or_gnb_relation_or_db_when_pebble_ready_then_nms_resources_are_not_updated(  # noqa: E501
         self,
@@ -1642,6 +1658,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 hostname="my_host", port=4567, token="test-token"
             )
             self.mock_delete_upf.assert_not_called()
+            self.mock_update_upf.assert_not_called()
 
     def test_given_gnb_exists_in_nms_and_new_fiveg_core_gnb_relation_is_added_when_pebble_ready_then_second_gnb_is_added_to_nms(  # noqa: E501
         self,
@@ -1732,6 +1749,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 name="my_gnb", tac=1, token="test-token"
             )
             self.mock_delete_gnb.assert_not_called()
+            self.mock_update_gnb.assert_not_called()
 
     def test_given_two_n4_relations_when_n4_relation_broken_then_upf_is_removed_from_nms(
         self,
@@ -1831,6 +1849,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 hostname="some.host.name", token="test-token"
             )
             self.mock_create_upf.assert_not_called()
+            self.mock_update_upf.assert_not_called()
 
     def test_given_two_fiveg_core_gnb_relations_when_relation_broken_then_gnb_is_removed_from_nms(
         self,
@@ -1926,8 +1945,9 @@ class TestCharmConfigure(NMSUnitTestFixtures):
 
             self.mock_delete_gnb.assert_called_once_with(name="some.gnb.name", token="test-token")
             self.mock_create_gnb.assert_not_called()
+            self.mock_update_gnb.assert_not_called()
 
-    def test_given_one_upf_in_nms_when_upf_is_modified_in_relation_then_nms_upfs_are_updated(  # noqa: E501
+    def test_given_one_upf_in_nms_when_upf_is_modified_in_relation_then_nms_upf_is_updated(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2011,14 +2031,102 @@ class TestCharmConfigure(NMSUnitTestFixtures):
 
             self.ctx.run(self.ctx.on.relation_joined(fiveg_n4_relation), state_in)
 
-            self.mock_delete_upf.assert_called_once_with(
-                hostname="some.host.name", token="test-token"
-            )
-            self.mock_create_upf.assert_called_once_with(
+            self.mock_delete_upf.assert_not_called()
+            self.mock_create_upf.assert_not_called()
+            self.mock_update_upf.assert_called_once_with(
                 hostname="some.host.name", port=22, token="test-token"
             )
 
-    def test_given_one_gnb_in_nms_when_gnb_is_modified_in_relation_then_nms_gnbs_are_updated(  # noqa: E501
+    def test_given_one_gnb_in_nms_when_gnb_is_modified_in_relation_then_nms_gnb_is_updated(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tempdir:
+            common_database_relation = scenario.Relation(
+                endpoint="common_database",
+                interface="mongodb_client",
+                remote_app_data={
+                    "username": "banana",
+                    "password": "pizza",
+                    "uris": "1.1.1.1:1234",
+                },
+            )
+            auth_database_relation = scenario.Relation(
+                endpoint="auth_database",
+                interface="mongodb_client",
+                remote_app_data={
+                    "username": "banana",
+                    "password": "pizza",
+                    "uris": "2.2.2.2:1234",
+                },
+            )
+            webui_database_relation = scenario.Relation(
+                endpoint="webui_database",
+                interface="mongodb_client",
+                remote_app_data={
+                    "username": "carrot",
+                    "password": "hotdog",
+                    "uris": "1.1.1.1:1234",
+                },
+            )
+            certificates_relation = scenario.Relation(
+                endpoint="certificates", interface="tls-certificates"
+            )
+            existing_gnbs = [
+                GnodeB(name="some.gnb.name", tac=34),
+            ]
+            self.mock_list_gnbs.return_value = existing_gnbs
+            config_mount = scenario.Mount(
+                location="/nms/config",
+                source=tempdir,
+            )
+            certs_mount = scenario.Mount(
+                location="/support/TLS",
+                source=tempdir,
+            )
+            container = scenario.Container(
+                name="nms",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                    "certs": certs_mount,
+                },
+            )
+            fiveg_core_gnb_relation = scenario.Relation(
+                endpoint="fiveg_core_gnb",
+                interface="fiveg_core_gnb",
+                remote_app_data={
+                    "gnb-name": "some.gnb.name",
+                },
+            )
+            login_secret = scenario.Secret(
+                {"username": "hello", "password": "world", "token": "test-token"},
+                id="1",
+                label="NMS_LOGIN",
+                owner="app",
+            )
+            state_in = scenario.State(
+                leader=True,
+                containers={container},
+                secrets={login_secret},
+                relations={
+                    common_database_relation,
+                    auth_database_relation,
+                    webui_database_relation,
+                    certificates_relation,
+                    fiveg_core_gnb_relation,
+                },
+            )
+            self.mock_certificate_is_available.return_value = True
+
+            self.ctx.run(self.ctx.on.relation_changed(fiveg_core_gnb_relation), state_in)
+
+            self.mock_delete_gnb.assert_not_called()
+            self.mock_create_gnb.assert_not_called()
+            self.mock_update_gnb.assert_called_once_with(
+                name="some.gnb.name", tac=1, token="test-token"
+            )
+
+    def test_given_one_gnb_in_nms_when_gnb_is_added_in_relation_then_old_gnb_is_removed_and_new_is_created(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2102,11 +2210,12 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             self.ctx.run(self.ctx.on.relation_changed(fiveg_core_gnb_relation), state_in)
 
             self.mock_delete_gnb.assert_called_once_with(name="some.gnb.name", token="test-token")
+            self.mock_update_gnb.assert_not_called()
             self.mock_create_gnb.assert_called_once_with(
                 name="some.new.gnb.name", tac=1, token="test-token"
             )
 
-    def test_given_one_upf_in_nms_when_new_upf_is_added_then_old_upf_is_removed_and_new_upf_is_added(  # noqa: E501
+    def test_given_one_upf_in_nms_when_new_upf_is_added_then_old_upf_is_removed_and_new_upf_is_created(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2191,6 +2300,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             self.ctx.run(self.ctx.on.relation_joined(fiveg_n4_relation), state_in)
 
             self.mock_delete_upf.assert_called_once_with(hostname="old.name", token="test-token")
+            self.mock_update_upf.assert_not_called()
             self.mock_create_upf.assert_called_once_with(
                 hostname="some.host.name", port=22, token="test-token"
             )

--- a/tests/unit/test_nms.py
+++ b/tests/unit/test_nms.py
@@ -126,7 +126,7 @@ class TestNMS:
         self.nms.create_gnb(name="some.gnb.name", tac=111, token="some_token")
 
         self.mock_request.assert_called_once_with(
-            method="POST",
+            method="PUT",
             url="some_url/config/v1/inventory/gnb/some.gnb.name",
             headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
             json={"tac": "111"},
@@ -137,7 +137,7 @@ class TestNMS:
         self.nms.create_gnb(name="some.gnb.name", tac=111, token="some_token")
 
         self.mock_request.assert_called_once_with(
-            method="POST",
+            method="PUT",
             url="some_url/config/v1/inventory/gnb/some.gnb.name",
             headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
             json={"tac": "111"},
@@ -269,7 +269,7 @@ class TestNMS:
         self.nms.create_upf(hostname="some.upf.name", port=111, token="some_token")
 
         self.mock_request.assert_called_once_with(
-            method="POST",
+            method="PUT",
             url="some_url/config/v1/inventory/upf/some.upf.name",
             headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
             json={"port": "111"},
@@ -280,7 +280,7 @@ class TestNMS:
         self.nms.create_upf(hostname="some.upf.name", port=22, token="some_token")
 
         self.mock_request.assert_called_once_with(
-            method="POST",
+            method="PUT",
             url="some_url/config/v1/inventory/upf/some.upf.name",
             headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
             json={"port": "22"},

--- a/tests/unit/test_nms.py
+++ b/tests/unit/test_nms.py
@@ -126,6 +126,41 @@ class TestNMS:
         self.nms.create_gnb(name="some.gnb.name", tac=111, token="some_token")
 
         self.mock_request.assert_called_once_with(
+            method="POST",
+            url="some_url/config/v1/inventory/gnb",
+            headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
+            json={"name": "some.gnb.name", "tac": "111"},
+            verify=False,
+        )
+
+    def test_given_a_valid_gnb_when_create_gnb_then_gnb_is_added_to_nms(self):
+        self.nms.create_gnb(name="some.gnb.name", tac=111, token="some_token")
+
+        self.mock_request.assert_called_once_with(
+            method="POST",
+            url="some_url/config/v1/inventory/gnb",
+            headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
+            json={"name": "some.gnb.name", "tac": "111"},
+            verify=False,
+        )
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(
+                mock_response_with_http_error_exception,
+            ),
+            pytest.param(
+                mock_response_with_connection_error_exception,
+            ),
+        ],
+    )
+    def test_given_exception_is_raised_when_update_gnb_then_exception_is_handled(self, exception):
+        self.mock_request.side_effect = exception()
+
+        self.nms.update_gnb(name="some.gnb.name", tac=111, token="some_token")
+
+        self.mock_request.assert_called_once_with(
             method="PUT",
             url="some_url/config/v1/inventory/gnb/some.gnb.name",
             headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
@@ -133,8 +168,8 @@ class TestNMS:
             verify=False,
         )
 
-    def test_given_a_valid_gnb_when_create_gnb_then_gnb_is_added_to_nms(self):
-        self.nms.create_gnb(name="some.gnb.name", tac=111, token="some_token")
+    def test_given_a_valid_gnb_when_update_gnb_then_gnb_is_added_to_nms(self):
+        self.nms.update_gnb(name="some.gnb.name", tac=111, token="some_token")
 
         self.mock_request.assert_called_once_with(
             method="PUT",
@@ -269,6 +304,41 @@ class TestNMS:
         self.nms.create_upf(hostname="some.upf.name", port=111, token="some_token")
 
         self.mock_request.assert_called_once_with(
+            method="POST",
+            url="some_url/config/v1/inventory/upf",
+            headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
+            json={"hostname": "some.upf.name", "port": "111"},
+            verify=False,
+        )
+
+    def test_given_a_valid_upf_when_create_upf_then_upf_is_added_to_nms(self):
+        self.nms.create_upf(hostname="some.upf.name", port=22, token="some_token")
+
+        self.mock_request.assert_called_once_with(
+            method="POST",
+            url="some_url/config/v1/inventory/upf",
+            headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
+            json={"hostname": "some.upf.name", "port": "22"},
+            verify=False,
+        )
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(
+                mock_response_with_http_error_exception,
+            ),
+            pytest.param(
+                mock_response_with_connection_error_exception,
+            ),
+        ],
+    )
+    def test_given_exception_is_raised_when_update_upf_then_exception_is_handled(self, exception):
+        self.mock_request.side_effect = exception()
+
+        self.nms.update_upf(hostname="some.upf.name", port=111, token="some_token")
+
+        self.mock_request.assert_called_once_with(
             method="PUT",
             url="some_url/config/v1/inventory/upf/some.upf.name",
             headers={"Content-Type": "application/json", "Authorization": "Bearer some_token"},
@@ -276,8 +346,8 @@ class TestNMS:
             verify=False,
         )
 
-    def test_given_a_valid_upf_when_create_upf_then_upf_is_added_to_nms(self):
-        self.nms.create_upf(hostname="some.upf.name", port=22, token="some_token")
+    def test_given_a_valid_upf_when_update_upf_then_upf_is_added_to_nms(self):
+        self.nms.update_upf(hostname="some.upf.name", port=22, token="some_token")
 
         self.mock_request.assert_called_once_with(
             method="PUT",


### PR DESCRIPTION
# Description

After https://github.com/omec-project/webconsole/pull/278 and https://github.com/omec-project/webconsole/pull/297 
We need to update the API calls in the charm.

We use POST to create and PUT to update gNBs and UPFs.

If a UPF/gNB updates it's port/tac in the relation, and the UPF/gNB already exists in the DB, we update it, instead of delete and recreate as before. This avoids sending unnecessary pebble notices 

NMS Image was updated here https://github.com/canonical/sdcore-nms/pull/720

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library