### PR TITLE
fix: Expose swagger API at the right URL

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -69,9 +69,7 @@ platforms:
 parts:
   charm:
     source: .
-    plugin: charm
-    charm-requirements:
-      - requirements.txt
+    plugin: uv
     build-packages:
       - libffi-dev
       - libssl-dev
@@ -81,7 +79,6 @@ parts:
       - rustup
     override-build: |
       rustup default stable
-      uv export --frozen --no-dev -o requirements.txt
       craftctl default
 
 config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from ipaddress import IPv4Address
 from subprocess import CalledProcessError, check_output
 from typing import List, Optional, cast
+from urllib.parse import urlparse
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
@@ -640,6 +641,14 @@ class SDCoreNMSOperatorCharm(CharmBase):
 
     @property
     def _nms_endpoint(self) -> str:
+        ingress_url = self.ingress.url
+        if ingress_url:
+            try:
+                netloc = urlparse(ingress_url).netloc
+                if netloc:
+                    return netloc
+            except ValueError as e:
+                logger.info("Error parsing the ingress URL: %s", e)
         return f"{_get_pod_ip()}:{NMS_URL_PORT}"
 
     @property

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -504,173 +504,91 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 }
             )
 
-    @patch("charms.traefik_k8s.v2.ingress.IngressPerAppRequirer.url", "/banana")
+    @pytest.mark.parametrize("url", ["/banana", "https://$&*$&[%/"])
     def test_given_container_is_ready_db_relations_exist_and_storage_attached_and_ingress_url_no_netloc_when_pebble_ready_then_pebble_plan_is_applied(  # noqa: E501
         self,
+        url
     ):
-        self.mock_nms_login.return_value = None
-        with tempfile.TemporaryDirectory() as tempdir:
-            common_database_relation = scenario.Relation(
-                endpoint="common_database",
-                interface="mongodb_client",
-                remote_app_data={
-                    "username": "banana",
-                    "password": "pizza",
-                    "uris": "1.1.1.1:1234",
-                },
-            )
-            auth_database_relation = scenario.Relation(
-                endpoint="auth_database",
-                interface="mongodb_client",
-                remote_app_data={
-                    "username": "banana",
-                    "password": "pizza",
-                    "uris": "2.2.2.2:1234",
-                },
-            )
-            webui_database_relation = scenario.Relation(
-                endpoint="webui_database",
-                interface="mongodb_client",
-                remote_app_data={
-                    "username": "carrot",
-                    "password": "hotdog",
-                    "uris": "1.1.1.1:1234",
-                },
-            )
-            certificates_relation = scenario.Relation(
-                endpoint="certificates", interface="tls-certificates"
-            )
-            config_mount = scenario.Mount(
-                location="/nms/config",
-                source=tempdir,
-            )
-            certs_mount = scenario.Mount(
-                location="/support/TLS",
-                source=tempdir,
-            )
-            container = scenario.Container(
-                name="nms",
-                can_connect=True,
-                mounts={
-                    "config": config_mount,
-                    "certs": certs_mount,
-                },
-            )
-            state_in = scenario.State(
-                leader=True,
-                containers={container},
-                relations={
-                    common_database_relation,
-                    auth_database_relation,
-                    webui_database_relation,
-                    certificates_relation,
-                },
-            )
-            self.mock_certificate_is_available.return_value = True
-
-            state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
-
-            assert state_out.get_container("nms").layers["nms"] == Layer(
-                {
-                    "summary": "NMS layer",
-                    "description": "pebble config layer for the NMS",
-                    "services": {
-                        "nms": {
-                            "startup": "enabled",
-                            "override": "replace",
-                            "command": "/bin/webconsole --cfg /nms/config/nmscfg.conf",
-                            "environment": {
-                                "CONFIGPOD_DEPLOYMENT": "5G",
-                                "WEBUI_ENDPOINT": "None:5000",
-                            },
-                        }
+        with patch("charms.traefik_k8s.v2.ingress.IngressPerAppRequirer.url", url):
+            self.mock_nms_login.return_value = None
+            with tempfile.TemporaryDirectory() as tempdir:
+                common_database_relation = scenario.Relation(
+                    endpoint="common_database",
+                    interface="mongodb_client",
+                    remote_app_data={
+                        "username": "banana",
+                        "password": "pizza",
+                        "uris": "1.1.1.1:1234",
                     },
-                }
-            )
-
-    @patch("charms.traefik_k8s.v2.ingress.IngressPerAppRequirer.url", "https://$&*$&[%/")
-    def test_given_container_is_ready_db_relations_exist_and_storage_attached_and_ingress_url_invalid_when_pebble_ready_then_pebble_plan_is_applied(  # noqa: E501
-        self,
-    ):
-        self.mock_nms_login.return_value = None
-        with tempfile.TemporaryDirectory() as tempdir:
-            common_database_relation = scenario.Relation(
-                endpoint="common_database",
-                interface="mongodb_client",
-                remote_app_data={
-                    "username": "banana",
-                    "password": "pizza",
-                    "uris": "1.1.1.1:1234",
-                },
-            )
-            auth_database_relation = scenario.Relation(
-                endpoint="auth_database",
-                interface="mongodb_client",
-                remote_app_data={
-                    "username": "banana",
-                    "password": "pizza",
-                    "uris": "2.2.2.2:1234",
-                },
-            )
-            webui_database_relation = scenario.Relation(
-                endpoint="webui_database",
-                interface="mongodb_client",
-                remote_app_data={
-                    "username": "carrot",
-                    "password": "hotdog",
-                    "uris": "1.1.1.1:1234",
-                },
-            )
-            certificates_relation = scenario.Relation(
-                endpoint="certificates", interface="tls-certificates"
-            )
-            config_mount = scenario.Mount(
-                location="/nms/config",
-                source=tempdir,
-            )
-            certs_mount = scenario.Mount(
-                location="/support/TLS",
-                source=tempdir,
-            )
-            container = scenario.Container(
-                name="nms",
-                can_connect=True,
-                mounts={
-                    "config": config_mount,
-                    "certs": certs_mount,
-                },
-            )
-            state_in = scenario.State(
-                leader=True,
-                containers={container},
-                relations={
-                    common_database_relation,
-                    auth_database_relation,
-                    webui_database_relation,
-                    certificates_relation,
-                },
-            )
-            self.mock_certificate_is_available.return_value = True
-
-            state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
-
-            assert state_out.get_container("nms").layers["nms"] == Layer(
-                {
-                    "summary": "NMS layer",
-                    "description": "pebble config layer for the NMS",
-                    "services": {
-                        "nms": {
-                            "startup": "enabled",
-                            "override": "replace",
-                            "command": "/bin/webconsole --cfg /nms/config/nmscfg.conf",
-                            "environment": {
-                                "CONFIGPOD_DEPLOYMENT": "5G",
-                                "WEBUI_ENDPOINT": "None:5000",
-                            },
-                        }
+                )
+                auth_database_relation = scenario.Relation(
+                    endpoint="auth_database",
+                    interface="mongodb_client",
+                    remote_app_data={
+                        "username": "banana",
+                        "password": "pizza",
+                        "uris": "2.2.2.2:1234",
                     },
-                }
-            )
+                )
+                webui_database_relation = scenario.Relation(
+                    endpoint="webui_database",
+                    interface="mongodb_client",
+                    remote_app_data={
+                        "username": "carrot",
+                        "password": "hotdog",
+                        "uris": "1.1.1.1:1234",
+                    },
+                )
+                certificates_relation = scenario.Relation(
+                    endpoint="certificates", interface="tls-certificates"
+                )
+                config_mount = scenario.Mount(
+                    location="/nms/config",
+                    source=tempdir,
+                )
+                certs_mount = scenario.Mount(
+                    location="/support/TLS",
+                    source=tempdir,
+                )
+                container = scenario.Container(
+                    name="nms",
+                    can_connect=True,
+                    mounts={
+                        "config": config_mount,
+                        "certs": certs_mount,
+                    },
+                )
+                state_in = scenario.State(
+                    leader=True,
+                    containers={container},
+                    relations={
+                        common_database_relation,
+                        auth_database_relation,
+                        webui_database_relation,
+                        certificates_relation,
+                    },
+                )
+                self.mock_certificate_is_available.return_value = True
+
+                state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+                assert state_out.get_container("nms").layers["nms"] == Layer(
+                    {
+                        "summary": "NMS layer",
+                        "description": "pebble config layer for the NMS",
+                        "services": {
+                            "nms": {
+                                "startup": "enabled",
+                                "override": "replace",
+                                "command": "/bin/webconsole --cfg /nms/config/nmscfg.conf",
+                                "environment": {
+                                    "CONFIGPOD_DEPLOYMENT": "5G",
+                                    "WEBUI_ENDPOINT": "None:5000",
+                                },
+                            }
+                        },
+                    }
+                )
 
     def test_given_mandatory_relations_do_not_exist_when_pebble_ready_then_pebble_plan_is_empty(
         self,

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ lib_path = {toxinidir}/lib/charms/sdcore_nms_k8s/v0/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]lib_path}
 
 [testenv]
+runner = uv-venv-lock-runner
+with_dev = true
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
   PYTHONBREAKPOINT=pdb.set_trace


### PR DESCRIPTION
# Description

The URL of the swagger API documentation was not set properly when the application is behind Traefik. This updates the Pebble layer to configure it properly based on the content of the ingress relation.

Fixes https://github.com/canonical/sdcore-nms/issues/715

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library