### PR TITLE
fix: use ops 2.17.1 in the mock charm

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -143,7 +143,7 @@ async def _deploy_amf_mock(ops_test: OpsTest):
         channel="beta",
         config={
             "src-overwrite": json.dumps(any_charm_src_overwrite),
-            "python-packages": "pytest-interface-tester"
+            "python-packages": "ops==2.17.1\npytest-interface-tester"
         },
     )
 


### PR DESCRIPTION
# Description

Install hook in the mock charm is failing to find `scenario.runtime` which is imported from `ops`.
This causes failure in integration tests.
The scenario.runtime library relies on ops==2.17.x.
Latest version of ops have breaking changes that make these libraries incompatible.

As a workaround we need to pin the ops version until incompatibilities are solved in the dependent projects.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library