### PR TITLE
fix: fix integration tests unstability

### DIFF
--- a/src/nms.py
+++ b/src/nms.py
@@ -195,6 +195,7 @@ class NMS:
 
     def list_gnbs(self, token: str) -> List[GnodeB]:
         """List gNBs from the NMS inventory."""
+        logger.info("Listing NMS gNBs")
         response = self._make_request("GET", f"/{GNB_CONFIG_URL}", token=token)
         if not response:
             return []
@@ -220,7 +221,7 @@ class NMS:
         self._make_request(
             "PUT", f"/{GNB_CONFIG_URL}/{name}", data=asdict(update_gnb_params), token=token
         )
-        logger.info("gNB %s created in NMS", name)
+        logger.info("gNB %s updated in NMS", name)
 
     def delete_gnb(self, name: str, token: str) -> None:
         """Delete a gNB list from the NMS inventory."""

--- a/src/nms.py
+++ b/src/nms.py
@@ -229,6 +229,7 @@ class NMS:
 
     def list_upfs(self, token: str) -> List[Upf]:
         """List UPFs from the NMS inventory."""
+        logger.info("Listing NMS UPFs")
         response = self._make_request("GET", f"/{UPF_CONFIG_URL}", token=token)
         if not response:
             return []

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -343,6 +343,7 @@ async def test_given_nms_related_to_upf_and_upf_status_is_active_then_nms_invent
 
     t0 = time.time()
     timeout = 180  # seconds
+    upfs = []
     while time.time() - t0 < timeout:
         admin_credentials = await get_nms_credentials(ops_test)
         token = admin_credentials.get("token")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -337,13 +337,13 @@ async def test_given_nms_related_to_upf_and_upf_status_is_active_then_nms_invent
     ops_test: OpsTest, deploy
 ):
     assert ops_test.model
-    admin_credentials = await get_nms_credentials(ops_test)
-    token = admin_credentials.get("token")
-    assert token
     await ops_test.model.wait_for_idle(apps=[UPF_CHARM_NAME], status="active", timeout=TIMEOUT)
     nms_url = await get_sdcore_nms_external_endpoint(ops_test)
     nms_client = NMS(url=nms_url)
 
+    admin_credentials = await get_nms_credentials(ops_test)
+    token = admin_credentials.get("token")
+    assert token
     upfs = nms_client.list_upfs(token=token)
 
     expected_upf_hostname = f"{UPF_CHARM_NAME}-external.{ops_test.model.name}.svc.cluster.local"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -207,20 +207,6 @@ def ui_is_running(nms_endpoint: str) -> bool:
     return False
 
 
-def get_nms_inventory_resource(url: str) -> List:
-    t0 = time.time()
-    timeout = 100  # seconds
-    while time.time() - t0 < timeout:
-        try:
-            response = requests.get(url=url, timeout=5)
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error("Cannot connect to the nms inventory: %s", e)
-        time.sleep(2)
-    return []
-
-
 async def get_nms_credentials(ops_test: OpsTest) -> dict[str, str]:
     assert ops_test.model
     secrets = await ops_test.model.list_secrets(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -350,7 +350,7 @@ async def test_given_nms_related_to_upf_and_upf_status_is_active_then_nms_invent
         upfs = nms_client.list_upfs(token=token)
         if upfs:
             break
-        logger.info(f"Waiting for UPFs to be syncronized")
+        logger.info("Waiting for UPFs to be syncronized")
         time.sleep(10)
 
     expected_upf_hostname = f"{UPF_CHARM_NAME}-external.{ops_test.model.name}.svc.cluster.local"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -8,7 +8,6 @@ import time
 from base64 import b64decode
 from collections import Counter
 from pathlib import Path
-from typing import List
 
 import pytest
 import requests

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -350,7 +350,7 @@ async def test_given_nms_related_to_upf_and_upf_status_is_active_then_nms_invent
         upfs = nms_client.list_upfs(token=token)
         if upfs:
             break
-        logger.info("Waiting for UPFs to be syncronized")
+        logger.info("Waiting for UPFs to be synchronized")
         time.sleep(10)
 
     expected_upf_hostname = f"{UPF_CHARM_NAME}-external.{ops_test.model.name}.svc.cluster.local"


### PR DESCRIPTION
# Description

`test_given_nms_related_to_upf_and_upf_status_is_active_then_nms_inventory_contains_upf_information _` is failing. The reason: the list of UPF in the NMS in empty.

https://github.com/canonical/sdcore-nms-k8s-operator/actions/runs/13311071002/job/37225370333

The reason is an invalid token:
`nms:nms.py:150 /config/v1/inventory/upf request failed: code 401`

The NMS restarts, then we update the token in the secret but when we retrieve the secret to sync the gNBs and UPFs, the token is not up to date. It takes a couple of seconds before the `secret-changed` event is fired.

we are in a race condition, in which the secrets are not up to date when we want to update the NMS DB, so the test is unstable.

```
services:
  nms:
    command: /bin/webconsole --cfg /nms/config/nmscfg.conf
    environment:
      CONFIGPOD_DEPLOYMENT: 5G
      WEBUI_ENDPOINT: test-integration-s9yf-sdcore-nms-k8s.10.0.0.5.nip.io
    override: replace
    startup: enabled
summary: NMS layer

unit-sdcore-nms-k8s-0: 13:02:11 INFO unit.sdcore-nms-k8s/0.juju-log fiveg_n4:13: _get_admin_account eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Mzk1NDE1OTcsInVzZXJuYW1lIjoiY2hhcm0tYWRtaW4tT1ZHUCIsInJvbGUiOjF9.hh1qwJvV1MzPMuPqeVM6koIEtdSNU9xlaqRHCFoQAVk
unit-sdcore-nms-k8s-0: 13:02:11 INFO unit.sdcore-nms-k8s/0.juju-log fiveg_n4:13: _get_admin_account eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Mzk1NDE1OTcsInVzZXJuYW1lIjoiY2hhcm0tYWRtaW4tT1ZHUCIsInJvbGUiOjF9.hh1qwJvV1MzPMuPqeVM6koIEtdSNU9xlaqRHCFoQAVk
unit-sdcore-nms-k8s-0: 13:02:11 ERROR unit.sdcore-nms-k8s/0.juju-log fiveg_n4:13: /config/v1/account request failed: code 401. <Response [401]>
unit-sdcore-nms-k8s-0: 13:02:11 INFO unit.sdcore-nms-k8s/0.juju-log fiveg_n4:13: NMS Login
unit-sdcore-nms-k8s-0: 13:02:12 INFO unit.sdcore-nms-k8s/0.juju-log fiveg_n4:13: NMS Login details updated eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Mzk1NDE3MzEsInVzZXJuYW1lIjoiY2hhcm0tYWRtaW4tT1ZHUCIsInJvbGUiOjF9.LgAkLBn69VGcONzFp1BEyoLZWIKcuxX24TFbfHvh8QM
unit-sdcore-nms-k8s-0: 13:02:12 INFO unit.sdcore-nms-k8s/0.juju-log fiveg_n4:13: _get_admin_account eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Mzk1NDE1OTcsInVzZXJuYW1lIjoiY2hhcm0tYWRtaW4tT1ZHUCIsInJvbGUiOjF9.hh1qwJvV1MzPMuPqeVM6koIEtdSNU9xlaqRHCFoQAVk
```

Also, in the tests we : 
1. Get the token
2. Wait for the UPF to be active/ready
3. Get the UPF list from the NMS

But the UPF was taking too long to be ready and in the mean time the NMS restarts so the token is no longer valid on the test side.

## The fix

If the UPF list is empty we retry for 3 minutes before considering it a failure.
I also moved the order of actions so that we get the token as close as where it is used as possible.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library