### PR TITLE
feat: allow configuring gnb tac [DO NOT MERGE]

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -87,3 +87,9 @@ config:
       type: string
       default: info
       description: Log level for the NMS. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
+    gnb-tac:
+      type: integer
+      default: 1
+      description: |
+        The TAC value to use for the gNBs.
+        This value will be provided to integrated gNodeB's over the `fiveg_core_gnb` charm relation interface.

--- a/src/nms.py
+++ b/src/nms.py
@@ -24,6 +24,7 @@ JSON_HEADER = {"Content-Type": "application/json"}
 
 class NMSError(Exception):
     """Exception raised when an error occurs communicating with the NMS."""
+
     pass
 
 
@@ -32,7 +33,7 @@ class GnodeB:
     """Class to represent a gNB."""
 
     name: str
-    tac: int = 1
+    tac: int
     plmns: List[PLMNConfig] = field(default_factory=list)
 
 
@@ -88,8 +89,10 @@ class CreateUserParams:
 @dataclass
 class CreateGnbParams:
     """Parameters to create a gNB."""
+
     name: str
     tac: str
+
 
 @dataclass
 class UpdateGnbParams:
@@ -101,8 +104,10 @@ class UpdateGnbParams:
 @dataclass
 class CreateUPFParams:
     """Parameters to create a UPF."""
+
     hostname: str
     port: str
+
 
 @dataclass
 class UpdateUPFParams:
@@ -312,7 +317,9 @@ class NMS:
         we cast it to a human-readable integer.
         """
         try:
-            response = self._make_request("GET", f"/{NETWORK_SLICE_CONFIG_URL}/{slice_name}", token=token)  # noqa: E501
+            response = self._make_request(
+                "GET", f"/{NETWORK_SLICE_CONFIG_URL}/{slice_name}", token=token
+            )  # noqa: E501
         except NMSError:
             return None
         mcc = response["site-info"]["plmn"]["mcc"]

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -4,6 +4,7 @@ from ops.framework import EventBase, logger
 
 N2_RELATION_NAME = "provide-fiveg-n2"
 
+
 class AnyCharm(AnyCharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -128,6 +128,7 @@ async def _deploy_self_signed_certificates(ops_test: OpsTest):
         channel=TLS_PROVIDER_CHARM_CHANNEL,
     )
 
+
 async def _deploy_amf_mock(ops_test: OpsTest):
     fiveg_n2_lib_url = "https://github.com/canonical/sdcore-amf-k8s-operator/raw/main/lib/charms/sdcore_amf_k8s/v0/fiveg_n2.py"
     fiveg_n2_lib = requests.get(fiveg_n2_lib_url, timeout=10).text
@@ -142,7 +143,7 @@ async def _deploy_amf_mock(ops_test: OpsTest):
         channel="beta",
         config={
             "src-overwrite": json.dumps(any_charm_src_overwrite),
-            "python-packages": "ops==2.17.1\npytest-interface-tester"
+            "python-packages": "ops==2.17.1\npytest-interface-tester",
         },
     )
 
@@ -407,7 +408,7 @@ async def test_given_db_restored_then_credentials_are_restored_and_valid(
     assert password
     nms_url = await get_sdcore_nms_external_endpoint(ops_test)
     nms_client = NMS(url=nms_url)
-    token = nms_client.login(username=username, password = password)
+    token = nms_client.login(username=username, password=password)
     assert token
 
 

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/dummy_fiveg_core_gnb_provider_charm/src/dummy_provider_charm.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/dummy_fiveg_core_gnb_provider_charm/src/dummy_provider_charm.py
@@ -25,8 +25,7 @@ class DummyFivegCoreGnbProviderCharm(ops.CharmBase):
         )
         framework.observe(self.on.get_gnb_name_action, self._on_get_gnb_name_action)
         framework.observe(
-            self.on.get_gnb_name_invalid_action,
-            self._on_get_gnb_name_action_invalid
+            self.on.get_gnb_name_invalid_action, self._on_get_gnb_name_action_invalid
         )
 
     def _on_publish_gnb_config_action(self, event: ops.ActionEvent):
@@ -60,9 +59,8 @@ class DummyFivegCoreGnbProviderCharm(ops.CharmBase):
         }
         requirer_app_data = FivegCoreGnbRequirerAppData(**validated_data)
 
-        assert (
-                requirer_app_data.gnb_name ==
-                self.fiveg_core_gnb_provider.get_gnb_name(int(relation_id))
+        assert requirer_app_data.gnb_name == self.fiveg_core_gnb_provider.get_gnb_name(
+            int(relation_id)
         )
 
     def _on_get_gnb_name_action_invalid(self, event: ops.ActionEvent):

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/dummy_fiveg_core_gnb_requirer_charm/src/dummy_requirer_charm.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/dummy_fiveg_core_gnb_requirer_charm/src/dummy_requirer_charm.py
@@ -21,8 +21,7 @@ class DummyFivegCoreGnbRequirerCharm(ops.CharmBase):
         framework.observe(self.on.publish_gnb_name_action, self._on_publish_gnb_name)
         framework.observe(self.on.get_gnb_config_action, self._on_get_gnb_config_action)
         framework.observe(
-            self.on.get_gnb_config_invalid_action,
-            self._on_get_gnb_config_action_invalid
+            self.on.get_gnb_config_invalid_action, self._on_get_gnb_config_action_invalid
         )
 
     def _on_publish_gnb_name(self, event: ops.ActionEvent):

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_provider_interface.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_provider_interface.py
@@ -87,14 +87,12 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
-        state_out = self.ctx.run(self.ctx.on.action("publish-gnb-config", params=params),
-                                 state_in)
-        assert (
-            state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["tac"]
-            == str(TEST_TAC_VALID)
+        state_out = self.ctx.run(self.ctx.on.action("publish-gnb-config", params=params), state_in)
+        assert state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["tac"] == str(
+            TEST_TAC_VALID
         )
         rel_plmns = state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["plmns"]
         assert plmns == [PLMNConfig(**data) for data in json.loads(rel_plmns)]
@@ -114,7 +112,7 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_INVALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
         with pytest.raises(Exception) as exc:
@@ -136,7 +134,7 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_VALID),
-            "plmns": "[]"
+            "plmns": "[]",
         }
 
         with pytest.raises(Exception) as exc:
@@ -159,14 +157,12 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
-        state_out = self.ctx.run(self.ctx.on.action("publish-gnb-config", params=params),
-                                 state_in)
-        assert (
-                state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["tac"]
-                == str(TEST_TAC_VALID)
+        state_out = self.ctx.run(self.ctx.on.action("publish-gnb-config", params=params), state_in)
+        assert state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["tac"] == str(
+            TEST_TAC_VALID
         )
         rel_plmns = state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["plmns"]
         assert plmns == [PLMNConfig(**data) for data in json.loads(rel_plmns)]
@@ -178,7 +174,7 @@ class TestFivegCoreGnbProviderCharm:
         plmns = [PLMNConfig(mcc=TEST_MCC, mnc=TEST_MNC, sst=TEST_SST, sd=TEST_SD)]
         params = {
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
         # TODO: It seems like this should use event.fail() rather than raising.
@@ -200,7 +196,7 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
         # TODO: It seems like this should use event.fail() rather than raising.
@@ -209,12 +205,14 @@ class TestFivegCoreGnbProviderCharm:
 
         assert "Unit must be leader to set application relation data" in str(e.value)
 
-    def test_given_fiveg_core_gnb_relation_does_not_exist_when_publish_gnb_config_then_exception_is_raised(self):  # noqa E501
+    def test_given_fiveg_core_gnb_relation_does_not_exist_when_publish_gnb_config_then_exception_is_raised(  # noqa E501
+        self,
+    ):
         state_in = scenario.State(relations=[], leader=True)
         plmns = [PLMNConfig(mcc=TEST_MCC, mnc=TEST_MNC, sst=TEST_SST, sd=TEST_SD)]
         params = {
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
         with pytest.raises(Exception) as exc:
@@ -238,7 +236,9 @@ class TestFivegCoreGnbProviderCharm:
 
         self.ctx.run(self.ctx.on.action("get-gnb-name", params=params), state_in)
 
-    def test_given_fiveg_core_gnb_relation_does_not_exist_when_get_gnb_name_then_none_is_returned(self):  # noqa E501
+    def test_given_fiveg_core_gnb_relation_does_not_exist_when_get_gnb_name_then_none_is_returned(
+        self,
+    ):  # noqa E501
         state_in = scenario.State(relations=[], leader=True)
 
         self.ctx.run(self.ctx.on.action("get-gnb-name-invalid"), state_in)

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_requirer_interface.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_requirer_interface.py
@@ -21,13 +21,7 @@ class TestFivegCoreGnbRequirer:
                 "requires": {"fiveg_core_gnb": {"interface": "fiveg_core_gnb"}},
             },
             actions={
-                "publish-gnb-name": {
-                    "params": {
-                        "gnb-name": {
-                            "type": "string"
-                        }
-                    }
-                },
+                "publish-gnb-name": {"params": {"gnb-name": {"type": "string"}}},
                 "get-gnb-config": {
                     "params": {
                         "tac": {
@@ -55,14 +49,12 @@ class TestFivegCoreGnbRequirer:
             leader=True,
             relations={fiveg_core_gnb_relation},
         )
-        params = {
-            "gnb-name": GNB_NAME
-        }
+        params = {"gnb-name": GNB_NAME}
 
         state_out = self.ctx.run(self.ctx.on.action("publish-gnb-name", params=params), state_in)
         assert (
-                state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["gnb-name"]
-                == GNB_NAME
+            state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["gnb-name"]
+            == GNB_NAME
         )
 
     def test_given_gnb_config_in_relation_data_when_get_gnb_config_then_gnb_config_is_returned(  # noqa: E501
@@ -84,7 +76,9 @@ class TestFivegCoreGnbRequirer:
 
         self.ctx.run(self.ctx.on.action("get-gnb-config", params=params), state_in)
 
-    def test_given_fiveg_core_gnb_relation_does_not_exist_when_publish_gnb_name_then_exception_is_raised(self):  # noqa E501
+    def test_given_fiveg_core_gnb_relation_does_not_exist_when_publish_gnb_name_then_exception_is_raised(  # noqa E501
+        self,
+    ):
         state_in = scenario.State(relations=[], leader=True)
         params = {"gnb-name": GNB_NAME}
 

--- a/tests/unit/test_nms.py
+++ b/tests/unit/test_nms.py
@@ -16,18 +16,19 @@ def mock_response_with_http_error_exception() -> MagicMock:
     mock_response.text = "burrito"
     return mock_response
 
+
 def mock_response_with_connection_error_exception() -> MagicMock:
     mock_response = MagicMock()
-    mock_response.side_effect = requests.RequestException(
-        "Error connecting to NMS"
-    )
+    mock_response.side_effect = requests.RequestException("Error connecting to NMS")
     return mock_response
+
 
 def mock_response_with_json_error_exception() -> MagicMock:
     mock_response = MagicMock()
     mock_response.raise_for_status.return_value = None
     mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "doc", 0)
     return mock_response
+
 
 def mock_response_with_object(resource_object) -> MagicMock:
     mock_response = MagicMock()
@@ -307,10 +308,7 @@ class TestNMS:
             assert upf in upfs
         assert len(upfs) == 3
 
-    def test_given_cannot_connect_when_create_upf_then_exception_is_handled(
-        self,
-        caplog
-    ):
+    def test_given_cannot_connect_when_create_upf_then_exception_is_handled(self, caplog):
         self.mock_request.side_effect = requests.RequestException("Error connecting to NMS")
 
         self.nms.create_upf(hostname="some.upf.name", port=111, token="some_token")
@@ -324,10 +322,7 @@ class TestNMS:
         )
         assert "Error connecting to NMS" in caplog.text
 
-    def test_given_http_error_when_create_upf_then_exception_is_handled(
-        self,
-        caplog
-    ):
+    def test_given_http_error_when_create_upf_then_exception_is_handled(self, caplog):
         self.mock_request.return_value = mock_response_with_http_error_exception()
 
         self.nms.create_upf(hostname="some.upf.name", port=111, token="some_token")
@@ -532,7 +527,7 @@ class TestNMS:
             "site-info": {
                 "plmn": {"mcc": test_mcc, "mnc": test_mnc},
                 "gNodeBs": [{"name": test_gnb_name, "tac": 1}],
-            }
+            },
         }
         self.mock_request.return_value = mock_response_with_object(network_slice_json)
 
@@ -543,7 +538,7 @@ class TestNMS:
             test_mnc,
             int(test_sst),
             test_sd_int,
-            [GnodeB(name=test_gnb_name, tac=1, plmns=[])]
+            [GnodeB(name=test_gnb_name, tac=1, plmns=[])],
         )
 
     def test_given_nms_doesnt_return_network_slice_data_when_get_network_slice_then_none_is_returned(  # noqa: E501
@@ -591,8 +586,8 @@ class TestNMS:
 
     def test_given_username_and_password_valid_when_login_then_token_is_returned(self):
         self.mock_request.return_value = mock_response_with_object({"token": "supersecret"})
-        assert (
-            self.nms.login("admin", "Correct Staple Horse") == LoginResponse(token="supersecret")
+        assert self.nms.login("admin", "Correct Staple Horse") == LoginResponse(
+            token="supersecret"
         )
 
     def test_given_connection_error_when_login_then_none_is_returned(self):


### PR DESCRIPTION
# Description

DO NOT MERGE THIS CHANGE

## Overview

The Field Engineering team is trying to integrate our core with a partner's 5G radios. We currently harcode the TAC to 1, and the partner uses a different TAC. Here we allow configuring the TAC through a configuration option in the NMS. This is not how we'll want to design this feature in the long run, it's a simple workaround to get the demo running.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library