### PR TITLE
feat: allow configuring gnb tac [DO NOT MERGE] - 1.5

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -90,3 +90,9 @@ config:
       type: string
       default: info
       description: Log level for the NMS. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
+    gnb-tac:
+      type: integer
+      default: 1
+      description: |
+        The TAC value to use for the gNBs.
+        This value will be provided to integrated gNodeB's over the `fiveg_core_gnb` charm relation interface.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -91,7 +91,7 @@ config:
       default: info
       description: Log level for the NMS. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
     gnb-tac:
-      type: integer
+      type: int
       default: 1
       description: |
         The TAC value to use for the gNBs.

--- a/src/nms.py
+++ b/src/nms.py
@@ -27,7 +27,7 @@ class GnodeB:
     """Class to represent a gNB."""
 
     name: str
-    tac: int = 1
+    tac: int
     plmns: List[PLMNConfig] = field(default_factory=list)
 
 
@@ -252,7 +252,9 @@ class NMS:
         The SD value received in the Network Slice configuration is a hex. In this function
         we cast it to a human-readable integer.
         """
-        response = self._make_request("GET", f"/{NETWORK_SLICE_CONFIG_URL}/{slice_name}", token=token)  # noqa: E501
+        response = self._make_request(
+            "GET", f"/{NETWORK_SLICE_CONFIG_URL}/{slice_name}", token=token
+        )  # noqa: E501
         if not response:
             return None
         mcc = response["site-info"]["plmn"]["mcc"]

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -4,6 +4,7 @@ from ops.framework import EventBase, logger
 
 N2_RELATION_NAME = "provide-fiveg-n2"
 
+
 class AnyCharm(AnyCharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -131,6 +131,7 @@ async def _deploy_self_signed_certificates(ops_test: OpsTest):
         channel=TLS_PROVIDER_CHARM_CHANNEL,
     )
 
+
 async def _deploy_amf_mock(ops_test: OpsTest):
     fiveg_n2_lib_url = "https://github.com/canonical/sdcore-amf-k8s-operator/raw/main/lib/charms/sdcore_amf_k8s/v0/fiveg_n2.py"
     fiveg_n2_lib = requests.get(fiveg_n2_lib_url, timeout=10).text
@@ -145,7 +146,7 @@ async def _deploy_amf_mock(ops_test: OpsTest):
         channel="beta",
         config={
             "src-overwrite": json.dumps(any_charm_src_overwrite),
-            "python-packages": "pytest-interface-tester"
+            "python-packages": "pytest-interface-tester",
         },
     )
 
@@ -410,7 +411,7 @@ async def test_given_db_restored_then_credentials_are_restored_and_valid(
     assert password
     nms_url = await get_sdcore_nms_external_endpoint(ops_test)
     nms_client = NMS(url=nms_url)
-    token = nms_client.login(username=username, password = password)
+    token = nms_client.login(username=username, password=password)
     assert token
 
 

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/dummy_fiveg_core_gnb_provider_charm/src/dummy_provider_charm.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/dummy_fiveg_core_gnb_provider_charm/src/dummy_provider_charm.py
@@ -25,8 +25,7 @@ class DummyFivegCoreGnbProviderCharm(ops.CharmBase):
         )
         framework.observe(self.on.get_gnb_name_action, self._on_get_gnb_name_action)
         framework.observe(
-            self.on.get_gnb_name_invalid_action,
-            self._on_get_gnb_name_action_invalid
+            self.on.get_gnb_name_invalid_action, self._on_get_gnb_name_action_invalid
         )
 
     def _on_publish_gnb_config_action(self, event: ops.ActionEvent):
@@ -60,9 +59,8 @@ class DummyFivegCoreGnbProviderCharm(ops.CharmBase):
         }
         requirer_app_data = FivegCoreGnbRequirerAppData(**validated_data)
 
-        assert (
-                requirer_app_data.gnb_name ==
-                self.fiveg_core_gnb_provider.get_gnb_name(int(relation_id))
+        assert requirer_app_data.gnb_name == self.fiveg_core_gnb_provider.get_gnb_name(
+            int(relation_id)
         )
 
     def _on_get_gnb_name_action_invalid(self, event: ops.ActionEvent):

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/dummy_fiveg_core_gnb_requirer_charm/src/dummy_requirer_charm.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/dummy_fiveg_core_gnb_requirer_charm/src/dummy_requirer_charm.py
@@ -21,8 +21,7 @@ class DummyFivegCoreGnbRequirerCharm(ops.CharmBase):
         framework.observe(self.on.publish_gnb_name_action, self._on_publish_gnb_name)
         framework.observe(self.on.get_gnb_config_action, self._on_get_gnb_config_action)
         framework.observe(
-            self.on.get_gnb_config_invalid_action,
-            self._on_get_gnb_config_action_invalid
+            self.on.get_gnb_config_invalid_action, self._on_get_gnb_config_action_invalid
         )
 
     def _on_publish_gnb_name(self, event: ops.ActionEvent):

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_provider_interface.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_provider_interface.py
@@ -87,14 +87,12 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
-        state_out = self.ctx.run(self.ctx.on.action("publish-gnb-config", params=params),
-                                 state_in)
-        assert (
-            state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["tac"]
-            == str(TEST_TAC_VALID)
+        state_out = self.ctx.run(self.ctx.on.action("publish-gnb-config", params=params), state_in)
+        assert state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["tac"] == str(
+            TEST_TAC_VALID
         )
         rel_plmns = state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["plmns"]
         assert plmns == [PLMNConfig(**data) for data in json.loads(rel_plmns)]
@@ -114,7 +112,7 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_INVALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
         with pytest.raises(Exception) as exc:
@@ -136,7 +134,7 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_VALID),
-            "plmns": "[]"
+            "plmns": "[]",
         }
 
         with pytest.raises(Exception) as exc:
@@ -159,14 +157,12 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
-        state_out = self.ctx.run(self.ctx.on.action("publish-gnb-config", params=params),
-                                 state_in)
-        assert (
-                state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["tac"]
-                == str(TEST_TAC_VALID)
+        state_out = self.ctx.run(self.ctx.on.action("publish-gnb-config", params=params), state_in)
+        assert state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["tac"] == str(
+            TEST_TAC_VALID
         )
         rel_plmns = state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["plmns"]
         assert plmns == [PLMNConfig(**data) for data in json.loads(rel_plmns)]
@@ -178,7 +174,7 @@ class TestFivegCoreGnbProviderCharm:
         plmns = [PLMNConfig(mcc=TEST_MCC, mnc=TEST_MNC, sst=TEST_SST, sd=TEST_SD)]
         params = {
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
         # TODO: It seems like this should use event.fail() rather than raising.
@@ -200,7 +196,7 @@ class TestFivegCoreGnbProviderCharm:
         params = {
             "relation-id": str(fiveg_core_gnb_relation.id),
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
         # TODO: It seems like this should use event.fail() rather than raising.
@@ -209,12 +205,14 @@ class TestFivegCoreGnbProviderCharm:
 
         assert "Unit must be leader to set application relation data" in str(e.value)
 
-    def test_given_fiveg_core_gnb_relation_does_not_exist_when_publish_gnb_config_then_exception_is_raised(self):  # noqa E501
+    def test_given_fiveg_core_gnb_relation_does_not_exist_when_publish_gnb_config_then_exception_is_raised(  # noqa E501
+        self,
+    ):
         state_in = scenario.State(relations=[], leader=True)
         plmns = [PLMNConfig(mcc=TEST_MCC, mnc=TEST_MNC, sst=TEST_SST, sd=TEST_SD)]
         params = {
             "tac": str(TEST_TAC_VALID),
-            "plmns": json.dumps([plmn.asdict() for plmn in plmns])
+            "plmns": json.dumps([plmn.asdict() for plmn in plmns]),
         }
 
         with pytest.raises(Exception) as exc:
@@ -238,7 +236,9 @@ class TestFivegCoreGnbProviderCharm:
 
         self.ctx.run(self.ctx.on.action("get-gnb-name", params=params), state_in)
 
-    def test_given_fiveg_core_gnb_relation_does_not_exist_when_get_gnb_name_then_none_is_returned(self):  # noqa E501
+    def test_given_fiveg_core_gnb_relation_does_not_exist_when_get_gnb_name_then_none_is_returned(
+        self,
+    ):  # noqa E501
         state_in = scenario.State(relations=[], leader=True)
 
         self.ctx.run(self.ctx.on.action("get-gnb-name-invalid"), state_in)

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_requirer_interface.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_requirer_interface.py
@@ -21,13 +21,7 @@ class TestFivegCoreGnbRequirer:
                 "requires": {"fiveg_core_gnb": {"interface": "fiveg_core_gnb"}},
             },
             actions={
-                "publish-gnb-name": {
-                    "params": {
-                        "gnb-name": {
-                            "type": "string"
-                        }
-                    }
-                },
+                "publish-gnb-name": {"params": {"gnb-name": {"type": "string"}}},
                 "get-gnb-config": {
                     "params": {
                         "tac": {
@@ -55,14 +49,12 @@ class TestFivegCoreGnbRequirer:
             leader=True,
             relations={fiveg_core_gnb_relation},
         )
-        params = {
-            "gnb-name": GNB_NAME
-        }
+        params = {"gnb-name": GNB_NAME}
 
         state_out = self.ctx.run(self.ctx.on.action("publish-gnb-name", params=params), state_in)
         assert (
-                state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["gnb-name"]
-                == GNB_NAME
+            state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["gnb-name"]
+            == GNB_NAME
         )
 
     def test_given_gnb_config_in_relation_data_when_get_gnb_config_then_gnb_config_is_returned(  # noqa: E501
@@ -84,7 +76,9 @@ class TestFivegCoreGnbRequirer:
 
         self.ctx.run(self.ctx.on.action("get-gnb-config", params=params), state_in)
 
-    def test_given_fiveg_core_gnb_relation_does_not_exist_when_publish_gnb_name_then_exception_is_raised(self):  # noqa E501
+    def test_given_fiveg_core_gnb_relation_does_not_exist_when_publish_gnb_name_then_exception_is_raised(  # noqa E501
+        self,
+    ):
         state_in = scenario.State(relations=[], leader=True)
         params = {"gnb-name": GNB_NAME}
 

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -1466,7 +1466,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             certificates_relation = scenario.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            existing_gnbs = [GnodeB(name="some.gnb.name")]
+            existing_gnbs = [GnodeB(name="some.gnb.name", tac=1)]
             self.mock_list_gnbs.return_value = existing_gnbs
             config_mount = scenario.Mount(
                 location="/nms/config",
@@ -1729,9 +1729,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
 
             self.ctx.run(self.ctx.on.relation_changed(fiveg_core_gnb_relation_2), state_in)
 
-            self.mock_create_gnb.assert_called_once_with(
-                name="my_gnb", tac=1, token="test-token"
-            )
+            self.mock_create_gnb.assert_called_once_with(name="my_gnb", tac=1, token="test-token")
             self.mock_delete_gnb.assert_not_called()
 
     def test_given_two_n4_relations_when_n4_relation_broken_then_upf_is_removed_from_nms(
@@ -1868,8 +1866,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="certificates", interface="tls-certificates"
             )
             existing_gnbs = [
-                GnodeB(name="some.gnb.name"),
-                GnodeB(name="gnb.name"),
+                GnodeB(name="some.gnb.name", tac=1),
+                GnodeB(name="gnb.name", tac=1),
             ]
             self.mock_list_gnbs.return_value = existing_gnbs
             config_mount = scenario.Mount(
@@ -2054,7 +2052,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="certificates", interface="tls-certificates"
             )
             existing_gnbs = [
-                GnodeB(name="some.gnb.name"),
+                GnodeB(name="some.gnb.name", tac=1),
             ]
             self.mock_list_gnbs.return_value = existing_gnbs
             config_mount = scenario.Mount(
@@ -2272,8 +2270,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
         test_sst = 1
         test_sd = 102030
         test_plmn_config = PLMNConfig(test_mcc, test_mnc, test_sst, test_sd)
-        expected_local_app_data = {"tac": '1', "plmns": json.dumps([test_plmn_config.asdict()])}
-        with (tempfile.TemporaryDirectory() as tempdir):
+        expected_local_app_data = {"tac": "1", "plmns": json.dumps([test_plmn_config.asdict()])}
+        with tempfile.TemporaryDirectory() as tempdir:
             common_database_relation = scenario.Relation(
                 endpoint="common_database",
                 interface="mongodb_client",
@@ -2304,14 +2302,14 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             certificates_relation = scenario.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            self.mock_list_gnbs.return_value = [GnodeB(name=test_gnb_name)]
+            self.mock_list_gnbs.return_value = [GnodeB(name=test_gnb_name, tac=1)]
             self.mock_list_network_slices.return_value = ["default"]
             self.mock_get_network_slice.return_value = NetworkSlice(
                 mcc=test_mcc,
                 mnc=test_mnc,
                 sst=test_sst,
                 sd=test_sd,
-                gnodebs=[GnodeB(name=test_gnb_name)],
+                gnodebs=[GnodeB(name=test_gnb_name, tac=1)],
             )
             config_mount = scenario.Mount(
                 location="/nms/config",
@@ -2328,7 +2326,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                     "config": config_mount,
                     "certs": certs_mount,
                 },
-                notices=[test_pebble_notice]
+                notices=[test_pebble_notice],
             )
             fiveg_core_gnb_relation = scenario.Relation(
                 endpoint="fiveg_core_gnb",
@@ -2362,9 +2360,10 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 state_in,
             )
 
-            assert state_out.get_relation(
-                fiveg_core_gnb_relation.id
-            ).local_app_data == expected_local_app_data
+            assert (
+                state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data
+                == expected_local_app_data
+            )
 
     def test_given_two_gnbs_in_nms_when_network_slice_config_for_gnb_1_changes_then_gnb_2_config_is_not_updated_in_fiveg_core_gnb_relation_data(  # noqa: E501
         self,
@@ -2408,8 +2407,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="certificates", interface="tls-certificates"
             )
             self.mock_list_gnbs.return_value = [
-                GnodeB(name=test_gnb_name),
-                GnodeB(name=test_gnb_2_name),
+                GnodeB(name=test_gnb_name, tac=1),
+                GnodeB(name=test_gnb_2_name, tac=1),
             ]
             self.mock_list_network_slices.return_value = ["default"]
             self.mock_get_network_slice.return_value = NetworkSlice(
@@ -2417,7 +2416,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 mnc=test_mnc,
                 sst=test_sst,
                 sd=test_sd,
-                gnodebs=[GnodeB(name=test_gnb_name)],
+                gnodebs=[GnodeB(name=test_gnb_name, tac=1)],
             )
             config_mount = scenario.Mount(
                 location="/nms/config",
@@ -2434,7 +2433,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                     "config": config_mount,
                     "certs": certs_mount,
                 },
-                notices=[test_pebble_notice]
+                notices=[test_pebble_notice],
             )
             fiveg_core_gnb_relation = scenario.Relation(
                 endpoint="fiveg_core_gnb",
@@ -2494,10 +2493,10 @@ class TestCharmConfigure(NMSUnitTestFixtures):
         test_plmn_config = PLMNConfig(test_mcc, test_mnc, test_sst, test_sd)
         test_plmn_2_config = PLMNConfig(test_mcc_2, test_mnc_2, test_sst_2, test_sd_2)
         expected_local_app_data = {
-            "tac": '1',
+            "tac": "1",
             "plmns": json.dumps([test_plmn_config.asdict(), test_plmn_2_config.asdict()]),
         }
-        with (tempfile.TemporaryDirectory() as tempdir):
+        with tempfile.TemporaryDirectory() as tempdir:
             common_database_relation = scenario.Relation(
                 endpoint="common_database",
                 interface="mongodb_client",
@@ -2528,12 +2527,18 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             certificates_relation = scenario.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            self.mock_list_gnbs.return_value = [GnodeB(name=test_gnb_name)]
+            self.mock_list_gnbs.return_value = [GnodeB(name=test_gnb_name, tac=1)]
             self.mock_list_network_slices.return_value = ["slice_one", "slice_two"]
             self.mock_get_network_slice.side_effect = [
-                NetworkSlice(test_mcc, test_mnc, test_sst, test_sd, [GnodeB(name=test_gnb_name)]),
                 NetworkSlice(
-                    test_mcc_2, test_mnc_2, test_sst_2, test_sd_2, [GnodeB(name=test_gnb_name)]
+                    test_mcc, test_mnc, test_sst, test_sd, [GnodeB(name=test_gnb_name, tac=1)]
+                ),
+                NetworkSlice(
+                    test_mcc_2,
+                    test_mnc_2,
+                    test_sst_2,
+                    test_sd_2,
+                    [GnodeB(name=test_gnb_name, tac=1)],
                 ),
             ]
             config_mount = scenario.Mount(
@@ -2551,7 +2556,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                     "config": config_mount,
                     "certs": certs_mount,
                 },
-                notices=[test_pebble_notice]
+                notices=[test_pebble_notice],
             )
             fiveg_core_gnb_relation = scenario.Relation(
                 endpoint="fiveg_core_gnb",
@@ -2585,6 +2590,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 state_in,
             )
 
-            assert state_out.get_relation(
-                fiveg_core_gnb_relation.id
-            ).local_app_data == expected_local_app_data
+            assert (
+                state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data
+                == expected_local_app_data
+            )

--- a/tests/unit/test_nms.py
+++ b/tests/unit/test_nms.py
@@ -411,7 +411,7 @@ class TestNMS:
             "site-info": {
                 "plmn": {"mcc": test_mcc, "mnc": test_mnc},
                 "gNodeBs": [{"name": test_gnb_name, "tac": 1}],
-            }
+            },
         }
         self.mock_request.return_value = self.mock_response_with_object(network_slice_json)
 
@@ -422,7 +422,7 @@ class TestNMS:
             test_mnc,
             int(test_sst),
             test_sd_int,
-            [GnodeB(name=test_gnb_name, tac=1, plmns=[])]
+            [GnodeB(name=test_gnb_name, tac=1, plmns=[])],
         )
 
     def test_given_nms_doesnt_return_network_slice_data_when_get_network_slice_then_none_is_returned(  # noqa: E501


### PR DESCRIPTION
# Description

DO NOT MERGE THIS CHANGE

The Field Engineering team is trying to integrate our core with a partner's 5G radios. We currently harcode the TAC to 1, and the partner uses a different TAC. Here we allow configuring the TAC through a configuration option in the NMS. This is not how we'll want to design this feature in the long run, it's a simple workaround to get the demo running.

This change is made against the 1.5 release branch

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library