### PR TITLE
fix: dont generate password with ponctuation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -682,9 +682,8 @@ def _generate_password() -> str:
     pw.append(secrets.choice(string.ascii_lowercase))
     pw.append(secrets.choice(string.ascii_uppercase))
     pw.append(secrets.choice(string.digits))
-    pw.append(secrets.choice(string.punctuation))
     for i in range(8):
-        pw.append(secrets.choice(string.ascii_letters + string.digits + string.punctuation))
+        pw.append(secrets.choice(string.ascii_letters + string.digits))
     secrets.SystemRandom().shuffle(pw)
     return "".join(pw)
 


### PR DESCRIPTION
# Description

Generating a password with punctuation leads to issues in some rare occurrences (see details in #448 ). Here we remove punctuation from the password generated. Passwords will now only be composed of lowercase ascii, uppercase ascii, and digits.

Fixes #448 

## Removed values

```python
punctuation = r"""!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"""
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library