### PR TITLE
chore: add name validation for gNB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.idea
 .vscode/
 .coverage
+coverage.xml
 .mypy_cache/
 .tox/
 

--- a/lib/charms/sdcore_nms_k8s/v0/fiveg_core_gnb.py
+++ b/lib/charms/sdcore_nms_k8s/v0/fiveg_core_gnb.py
@@ -128,7 +128,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 
@@ -325,6 +325,7 @@ class FivegCoreGnbRequirerAppData(BaseModel):
         alias="gnb-name",
         description="CU/gNB unique identifier",
         examples=["gnb001"],
+        pattern="^[a-zA-Z][a-zA-Z0-9-_]{1,255}$"
     )
 
 

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_requirer_interface.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_requirer_interface.py
@@ -9,7 +9,6 @@ from tests.unit.lib.charms.sdcore_nms_k8s.v0.dummy_fiveg_core_gnb_requirer_charm
 )
 
 GNB_NAME = "gnb001"
-INVALID_GNB_NAME = "gnb?invalid"
 
 
 class TestFivegCoreGnbRequirer:
@@ -66,8 +65,9 @@ class TestFivegCoreGnbRequirer:
                 == GNB_NAME
         )
 
+    @pytest.mark.parametrize("gnb_name", ["gnb?invalid", "1-gnb", "longname"*32+"1"])
     def test_given_gnb_config_in_relation_data_when_publish_invalid_gnb_name_then_then_exception_is_raised(  # noqa: E501
-        self,
+        self, gnb_name
     ):
         fiveg_core_gnb_relation = scenario.Relation(
             endpoint="fiveg_core_gnb",
@@ -78,13 +78,13 @@ class TestFivegCoreGnbRequirer:
             relations={fiveg_core_gnb_relation},
         )
         params = {
-            "gnb-name": INVALID_GNB_NAME
+            "gnb-name": gnb_name
         }
 
         with pytest.raises(Exception) as exc:
             self.ctx.run(self.ctx.on.action("publish-gnb-name", params=params), state_in)
 
-        assert f"Invalid gNB name: {INVALID_GNB_NAME}" in str(exc.value)
+        assert f"Invalid gNB name: {gnb_name}" in str(exc.value)
 
     def test_given_gnb_config_in_relation_data_when_get_gnb_config_then_gnb_config_is_returned(  # noqa: E501
         self,

--- a/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_requirer_interface.py
+++ b/tests/unit/lib/charms/sdcore_nms_k8s/v0/test_fiveg_core_gnb_requirer_interface.py
@@ -9,6 +9,7 @@ from tests.unit.lib.charms.sdcore_nms_k8s.v0.dummy_fiveg_core_gnb_requirer_charm
 )
 
 GNB_NAME = "gnb001"
+INVALID_GNB_NAME = "gnb?invalid"
 
 
 class TestFivegCoreGnbRequirer:
@@ -64,6 +65,26 @@ class TestFivegCoreGnbRequirer:
                 state_out.get_relation(fiveg_core_gnb_relation.id).local_app_data["gnb-name"]
                 == GNB_NAME
         )
+
+    def test_given_gnb_config_in_relation_data_when_publish_invalid_gnb_name_then_then_exception_is_raised(  # noqa: E501
+        self,
+    ):
+        fiveg_core_gnb_relation = scenario.Relation(
+            endpoint="fiveg_core_gnb",
+            interface="fiveg_core_gnb",
+        )
+        state_in = scenario.State(
+            leader=True,
+            relations={fiveg_core_gnb_relation},
+        )
+        params = {
+            "gnb-name": INVALID_GNB_NAME
+        }
+
+        with pytest.raises(Exception) as exc:
+            self.ctx.run(self.ctx.on.action("publish-gnb-name", params=params), state_in)
+
+        assert f"Invalid gNB name: {INVALID_GNB_NAME}" in str(exc.value)
 
     def test_given_gnb_config_in_relation_data_when_get_gnb_config_then_gnb_config_is_returned(  # noqa: E501
         self,

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -930,7 +930,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             fiveg_n4_relation = scenario.Relation(
@@ -1103,7 +1103,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             fiveg_n4_relation = scenario.Relation(
@@ -1184,7 +1184,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             fiveg_n4_relation = scenario.Relation(
@@ -1278,7 +1278,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             fiveg_n4_relation = scenario.Relation(
@@ -1329,7 +1329,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
             self.mock_create_gnb.assert_called_once_with(
-                name="some.gnb.name", token="test-token"
+                name="some-gnb-name", token="test-token"
             )
             self.mock_delete_gnb.assert_not_called()
 
@@ -1468,7 +1468,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             fiveg_core_gnb_relation_2 = scenario.Relation(
@@ -1518,7 +1518,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
             calls = [
-                call(name="some.gnb.name", token="test-token"),
+                call(name="some-gnb-name", token="test-token"),
                 call(name="my_gnb", token="test-token"),
             ]
             self.mock_create_gnb.assert_has_calls(calls, any_order=True)
@@ -1644,7 +1644,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             certificates_relation = scenario.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            existing_gnbs = [GnodeB(name="some.gnb.name")]
+            existing_gnbs = [GnodeB(name="some-gnb-name")]
             self.mock_list_gnbs.return_value = existing_gnbs
             config_mount = scenario.Mount(
                 location="/nms/config",
@@ -1666,7 +1666,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             login_secret = scenario.Secret(
@@ -1858,7 +1858,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             certificates_relation = scenario.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            existing_gnbs = [GnodeB(name="some.gnb.name", tac=1)]
+            existing_gnbs = [GnodeB(name="some-gnb-name", tac=1)]
             self.mock_list_gnbs.return_value = existing_gnbs
             config_mount = scenario.Mount(
                 location="/nms/config",
@@ -1879,7 +1879,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
             fiveg_core_gnb_relation_1 = scenario.Relation(
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
-                remote_app_data={"gnb-name": "some.gnb.name"},
+                remote_app_data={"gnb-name": "some-gnb-name"},
             )
             fiveg_core_gnb_relation_2 = scenario.Relation(
                 endpoint="fiveg_core_gnb",
@@ -2049,8 +2049,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="certificates", interface="tls-certificates"
             )
             existing_gnbs = [
-                GnodeB(name="some.gnb.name"),
-                GnodeB(name="gnb.name"),
+                GnodeB(name="some-gnb-name"),
+                GnodeB(name="gnb-name"),
             ]
             self.mock_list_gnbs.return_value = existing_gnbs
             config_mount = scenario.Mount(
@@ -2073,14 +2073,14 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             fiveg_core_gnb_relation_2 = scenario.Relation(
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "gnb.name",
+                    "gnb-name": "gnb-name",
                 },
             )
             login_secret = scenario.Secret(
@@ -2106,7 +2106,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
 
             self.ctx.run(self.ctx.on.relation_broken(fiveg_core_gnb_relation_1), state_in)
 
-            self.mock_delete_gnb.assert_called_once_with(name="some.gnb.name", token="test-token")
+            self.mock_delete_gnb.assert_called_once_with(name="some-gnb-name", token="test-token")
             self.mock_create_gnb.assert_not_called()
 
     def test_given_one_upf_in_nms_when_upf_is_modified_in_relation_then_nms_upf_is_updated(  # noqa: E501
@@ -2234,7 +2234,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="certificates", interface="tls-certificates"
             )
             existing_gnbs = [
-                GnodeB(name="some.gnb.name"),
+                GnodeB(name="some-gnb-name"),
             ]
             self.mock_list_gnbs.return_value = existing_gnbs
             config_mount = scenario.Mount(
@@ -2257,7 +2257,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.new.gnb.name",
+                    "gnb-name": "some-new-gnb-name",
                 },
             )
             login_secret = scenario.Secret(
@@ -2282,9 +2282,9 @@ class TestCharmConfigure(NMSUnitTestFixtures):
 
             self.ctx.run(self.ctx.on.relation_changed(fiveg_core_gnb_relation), state_in)
 
-            self.mock_delete_gnb.assert_called_once_with(name="some.gnb.name", token="test-token")
+            self.mock_delete_gnb.assert_called_once_with(name="some-gnb-name", token="test-token")
             self.mock_create_gnb.assert_called_once_with(
-                name="some.new.gnb.name", token="test-token"
+                name="some-new-gnb-name", token="test-token"
             )
 
     def test_given_one_upf_in_nms_when_new_upf_is_added_then_old_upf_is_removed_and_new_upf_is_created(  # noqa: E501
@@ -2426,7 +2426,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             state_in = scenario.State(
@@ -2447,7 +2447,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
         self,
     ):
         test_pebble_notice = scenario.Notice("aetherproject.org/webconsole/networkslice/create")
-        test_gnb_name = "some.gnb.name"
+        test_gnb_name = "some-gnb-name"
         test_mcc = "123"
         test_mnc = "98"
         test_sst = 1
@@ -2516,7 +2516,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             login_secret = scenario.Secret(
@@ -2552,8 +2552,8 @@ class TestCharmConfigure(NMSUnitTestFixtures):
         self,
     ):
         test_pebble_notice = scenario.Notice("aetherproject.org/webconsole/networkslice/create")
-        test_gnb_name = "some.gnb.name"
-        test_gnb_2_name = "some.other.gnb.name"
+        test_gnb_name = "some-gnb-name"
+        test_gnb_2_name = "some-other-gnb-name"
         test_mcc = "123"
         test_mnc = "98"
         test_sst = 1
@@ -2664,7 +2664,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
         self,
     ):
         test_pebble_notice = scenario.Notice("aetherproject.org/webconsole/networkslice/create")
-        test_gnb_name = "some.gnb.name"
+        test_gnb_name = "some-gnb-name"
         test_mcc = "123"
         test_mcc_2 = "321"
         test_mnc = "98"
@@ -2744,7 +2744,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             login_secret = scenario.Secret(
@@ -2780,7 +2780,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
         self,
     ):
         test_pebble_notice = scenario.Notice("aetherproject.org/webconsole/networkslice/create")
-        test_gnb_name = "some.gnb.name"
+        test_gnb_name = "some-gnb-name"
         test_mcc = "123"
         test_mnc = "98"
         test_sst = 1
@@ -2845,7 +2845,7 @@ class TestCharmConfigure(NMSUnitTestFixtures):
                 endpoint="fiveg_core_gnb",
                 interface="fiveg_core_gnb",
                 remote_app_data={
-                    "gnb-name": "some.gnb.name",
+                    "gnb-name": "some-gnb-name",
                 },
             )
             login_secret = scenario.Secret(


### PR DESCRIPTION
# Description

This PR adds the regular expression validation for the gNB name in the `fiveg_core_gnb`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library