### PR TITLE
chore: use base instead of series for deployment in integration tests

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -104,7 +104,7 @@ async def _deploy_sdcore_upf(ops_test: OpsTest):
         application_name=UPF_CHARM_NAME,
         channel=UPF_CHARM_CHANNEL,
         trust=True,
-        series="noble",  # TODO: This should be replaced with base=SDCORE_CHARMS_BASE once it's properly supported  # noqa: E501
+        base=SDCORE_CHARMS_BASE
     )
 
 


### PR DESCRIPTION
# Description

This PR removes a workaround and specifies the base instead of series for charms that support 2 bases.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library